### PR TITLE
FUSETOOLS2-1426 - retrieve Debug Adapter Server at build time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 node_modules
 .vscode-test/
 *.vsix
+jars/camel-dap-server.jar

--- a/jars/Readme.md
+++ b/jars/Readme.md
@@ -1,0 +1,1 @@
+Keep this folder, it will be used to download during preinstall of the Apache Camel Debug Adapter Server Jar

--- a/package-lock.json
+++ b/package-lock.json
@@ -1249,6 +1249,41 @@
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 			"dev": true
 		},
+		"mvn-artifact-download": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/mvn-artifact-download/-/mvn-artifact-download-6.0.0.tgz",
+			"integrity": "sha512-/eIZ3/cgIm8NeE+ICq3xCvSNf3uvS7Tb/yEf8x5ACEoDcDuOwM88m2HXFUCeiqavF3irk0vWgX9VJN2tZkbqkQ==",
+			"dev": true,
+			"requires": {
+				"mvn-artifact-filename": "^6.0.0",
+				"mvn-artifact-name-parser": "^6.0.0",
+				"mvn-artifact-url": "^6.0.0",
+				"node-fetch": "^2.6.1"
+			}
+		},
+		"mvn-artifact-filename": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/mvn-artifact-filename/-/mvn-artifact-filename-6.0.0.tgz",
+			"integrity": "sha512-sDHE+LMJBylCSnRZYKBVhNAslJR9fdLaRynhHVdicxgRa36+TxvHHJl+AaEje1F0VSjejRr2ab/PG7lgV9Ar5Q==",
+			"dev": true
+		},
+		"mvn-artifact-name-parser": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/mvn-artifact-name-parser/-/mvn-artifact-name-parser-6.0.0.tgz",
+			"integrity": "sha512-ZWnGAMB/tHREFrH/6L3M13r+xiPJtyskKTnv7rHAbNoEKrzP6E3jeaLEwNceEVqfO7Px4iowVlYijJbCdDmijw==",
+			"dev": true
+		},
+		"mvn-artifact-url": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/mvn-artifact-url/-/mvn-artifact-url-6.0.0.tgz",
+			"integrity": "sha512-OOhwPzybaBV5KH4LJ2tR6MHC9cBiPSMtbY1e/mOqJ+ZYNyr6cILktLLDWmm3R46UVzALeOqFRK0sJnMq8ixeHA==",
+			"dev": true,
+			"requires": {
+				"mvn-artifact-filename": "^6.0.0",
+				"node-fetch": "^2.6.1",
+				"xml2js": "^0.4.23"
+			}
+		},
 		"nanoid": {
 			"version": "3.1.25",
 			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
@@ -1260,6 +1295,15 @@
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
 			"dev": true
+		},
+		"node-fetch": {
+			"version": "2.6.7",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+			"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+			"dev": true,
+			"requires": {
+				"whatwg-url": "^5.0.0"
+			}
 		},
 		"normalize-path": {
 			"version": "3.0.0",
@@ -1452,6 +1496,12 @@
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
 			"dev": true
 		},
+		"sax": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+			"dev": true
+		},
 		"semver": {
 			"version": "7.3.5",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -1556,6 +1606,12 @@
 				"is-number": "^7.0.0"
 			}
 		},
+		"tr46": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+			"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+			"dev": true
+		},
 		"traverse": {
 			"version": "0.3.9",
 			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
@@ -1637,6 +1693,22 @@
 			"integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
 			"dev": true
 		},
+		"webidl-conversions": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+			"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+			"dev": true
+		},
+		"whatwg-url": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+			"integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+			"dev": true,
+			"requires": {
+				"tr46": "~0.0.3",
+				"webidl-conversions": "^3.0.0"
+			}
+		},
 		"which": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -1679,6 +1751,22 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
 			"integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
+			"dev": true
+		},
+		"xml2js": {
+			"version": "0.4.23",
+			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+			"integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+			"dev": true,
+			"requires": {
+				"sax": ">=0.6.0",
+				"xmlbuilder": "~11.0.0"
+			}
+		},
+		"xmlbuilder": {
+			"version": "11.0.1",
+			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+			"integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
 			"dev": true
 		},
 		"y18n": {

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
 		"vscode:prepublish": "npm run compile",
 		"compile": "tsc -p ./",
 		"watch": "tsc -watch -p ./",
+		"postinstall": "node ./scripts/postinstall.js",
 		"pretest": "npm run compile && npm run lint",
 		"lint": "eslint src --ext ts",
 		"test": "node ./out/test/runTest.js"
@@ -95,6 +96,7 @@
 		"glob": "^7.2.0",
 		"mocha": "^9.1.3",
 		"mocha-jenkins-reporter": "^0.4.7",
+		"mvn-artifact-download": "^6.0.0",
 		"typescript": "^4.5.4"
 	}
 }

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,0 +1,11 @@
+'use strict';
+
+var lsp_server_version = "1.3.0-SNAPSHOT";
+
+const download = require("mvn-artifact-download").default;
+const fs = require('fs');
+const path = require('path');
+
+download('com.github.camel-tooling:camel-lsp-server:' + lsp_server_version, './jars/', 'https://oss.sonatype.org/content/repositories/snapshots/').then((filename)=>{
+	fs.renameSync(filename, path.join('.', 'jars', 'language-server.jar'));
+});

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const dapServerVersion = '0.0.1-SNAPSHOT';
+
+const download = require('mvn-artifact-download').default;
+const fs = require('fs');
+const path = require('path');
+
+download('com.github.camel-tooling:camel-dap-server:' + dapServerVersion, './jars/', 'https://oss.sonatype.org/content/repositories/snapshots/').then((filename)=>{
+	fs.renameSync(filename, path.join('.', 'jars', 'camel-dap-server.jar'));
+});

--- a/src/CamelDebugAdpaterDescriptorFactory.ts
+++ b/src/CamelDebugAdpaterDescriptorFactory.ts
@@ -11,7 +11,7 @@ export class CamelDebugAdapterDescriptorFactory implements vscode.DebugAdapterDe
 	createDebugAdapterDescriptor(session: vscode.DebugSession, executable: vscode.DebugAdapterExecutable | undefined): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
 		if(!executable) {
 			const command = 'java';
-			const jarPath = this.context.asAbsolutePath('jars/camel-dap-server-0.0.1-SNAPSHOT.jar');
+			const jarPath = this.context.asAbsolutePath('jars/camel-dap-server.jar');
 			const args = ['-jar', jarPath];
 			return new vscode.DebugAdapterExecutable(command, args);
 		}


### PR DESCRIPTION
it avoids to push the binaries in source code and it allows to pick
latest version more automatically

Signed-off-by: Aurélien Pupier <apupier@redhat.com>