### PR TITLE
FUSETOOLS2-1496 - allow manual build trigger

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,8 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-    
+  workflow_dispatch:
+
 jobs:
   build:
 


### PR DESCRIPTION
as we are consuming snapshots (yes, not ideal), it can be useful to
trigger the build manually to ensure latest snapshots is picked up in
tests before a release.

Signed-off-by: Aurélien Pupier <apupier@redhat.com>