### PR TITLE
FUSETOOLS2-1489 - Send telemetry from Camel debug adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to the "vscode-debug-adapter-apache-camel" extension will be
 - Add keywords to the extension to have a better discoverability in the Marketplace
 - Provide icon for the extension to improve visibility in marketplace. It also improve coherence with other `Camel Tooling` extensions
 - Provide license file at the root of the binary to better match `vsce` recommendations
+- Provide telemetry (opt-in) for success/failure of Camel debug session start
 
 ## 0.0.1
 

--- a/README.md
+++ b/README.md
@@ -44,3 +44,7 @@ The Camel instance to debug must follow these requirements:
   - Camel 3.15+
   - Have camel-debug on the classpath
   - Have JMX enabled
+
+## Usage data
+
+The Debug Adapter for Apache Camel by Red Hat extension collects anonymous [usage data](USAGE_DATA.md) and sends it to Red Hat servers to help improve our products and services. Read our [privacy statement](https://developers.redhat.com/article/tool-data-collection) to learn more. This extension respects the redhat.telemetry.enabled setting which you can learn more about at https://github.com/redhat-developer/vscode-redhat-telemetry#how-to-disable-telemetry-reporting

--- a/USAGE_DATA.md
+++ b/USAGE_DATA.md
@@ -1,1 +1,4 @@
-The Debug Adapter for Apache Camel by Red Hat extension collects anonymous [usage data](USAGE_DATA.md) and sends it to Red Hat servers to help improve our products and services. Read our [privacy statement](https://developers.redhat.com/article/tool-data-collection) to learn more. This extension respects the redhat.telemetry.enabled setting which you can learn more about at https://github.com/redhat-developer/vscode-redhat-telemetry#how-to-disable-telemetry-reporting
+# Collected data
+
+* when extension is activated
+* when Camel debug session is launched and if it is successfully attached


### PR DESCRIPTION
Currently no test setup is in place. it doesn't make sense to test from
at unit level so not adding tests for now.

requires https://github.com/camel-tooling/camel-debug-adapter/pull/58
![Screenshot from 2022-03-16 15-19-57](https://user-images.githubusercontent.com/1105127/158611122-cff026bb-1f01-4566-9fd7-68210b77e9af.png)

