### PR TITLE
FUSETOOLS2-1599 - changelog: support already set breakpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the "vscode-debug-adapter-apache-camel" extension will be
 - Upgrade Debug Adapter for Apache Camel to 0.3.0
 - Provide Codelens to `Debug with JBang`
 - Provide contextual menu on File Explorer to `Start Camel Application with JBang and debug`
+- Support setting breakpoints before starting the debugger
 
 ## 0.2.0
 


### PR DESCRIPTION
Now, when a breakpoint is set before starting the debugger, the
breakpoint is correctly used. The initializedEvent was sent at the wrong
time before, the debugger was not ready to accept the setBreakpoint
requests as the JMX connection was not ready.

requires https://github.com/camel-tooling/camel-debug-adapter/pull/94