### PR TITLE
FUSETOOLS2-1566 - upgrade node on Circle CI to version 16

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
         distribution: 'adopt'
     - uses: actions/setup-node@v2
       with:
-        node-version: '14'
+        node-version: '16'
         cache: 'npm'
     - name: Install global dependencies
       run: npm install -g typescript vsce


### PR DESCRIPTION
Signed-off-by: Aurélien Pupier <apupier@redhat.com>