### PR TITLE
FUSETOOLS2-1664 Suspend processing routes before debugger configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the "vscode-debug-adapter-apache-camel" extension will be
 
 ## 0.4.0
 
+- Await configuration of debugger set before processing Camel route (available with Camel Application 3.18+)
+
 ## 0.3.0
 
 - Upgrade Debug Adapter for Apache Camel to 0.3.0

--- a/src/completion/CamelApplicationLauncherTasksCompletionItemProvider.ts
+++ b/src/completion/CamelApplicationLauncherTasksCompletionItemProvider.ts
@@ -68,6 +68,7 @@ export class CamelApplicationLauncherTasksCompletionItemProvider implements vsco
 	"type": "shell",
 	"command": "jbang", // jbang binary must be available on command-line
 	"args": [
+		"-Dorg.apache.camel.debugger.suspend=true", // requires Camel 3.18+ to take effect
 		"-Dcamel.jbang.version=3.16.0", // to adapt to your Camel version. 3.16+ is required
 		"camel@apache/camel",
 		"run",

--- a/src/task/CamelJBangTaskProvider.ts
+++ b/src/task/CamelJBangTaskProvider.ts
@@ -32,7 +32,7 @@ export class CamelJBangTaskProvider implements TaskProvider {
 			TaskScope.Workspace,
 			CamelJBangTaskProvider.labelProvidedTask,
 			'camel',
-			new ShellExecution('jbang camel@apache/camel run ${relativeFile} --logging-level=info --dep=org.apache.camel:camel-debug'),
+			new ShellExecution('jbang -Dorg.apache.camel.debugger.suspend=true camel@apache/camel run ${relativeFile} --logging-level=info --dep=org.apache.camel:camel-debug'),
 			'$camel.debug.problemMatcher');
 		task.isBackground = true;
 		task.presentationOptions.reveal = TaskRevealKind.Always;


### PR DESCRIPTION
is done when launch with JBang

Signed-off-by: Aurélien Pupier <apupier@redhat.com>