### PR TITLE
Preparation for release of version with red hat support. Removed preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "vscode-debug-adapter-apache-camel" extension will be documented in this file.
 
+## 1.0.0
+
+- Release version of the extension, supported by Red Hat.
+
 ## 0.5.0
 
 - Upgrade Debug Adapter for Apache Camel to 0.5.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vscode-debug-adapter-apache-camel",
-	"version": "0.5.0",
+	"version": "1.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-debug-adapter-apache-camel",
-			"version": "0.5.0",
+			"version": "1.0.0",
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
 	"displayName": "Debug Adapter for Apache Camel by Red Hat",
 	"description": "Client for the Debug Adapter implementation for Apache Camel",
 	"license": "Apache-2.0",
-	"version": "0.5.0",
-	"preview": true,
+	"version": "1.0.0",
 	"publisher": "redhat",
 	"icon": "icons/icon128.png",
 	"repository": {


### PR DESCRIPTION
This is in preparation of the release with Red Hat's development support of this extension.

It follows https://github.com/camel-tooling/vscode-camel-extension-pack/pull/74 as what are the changes required for this

Related ticket: https://issues.redhat.com/browse/FUSETOOLS2-1684

Wont ask for a review until we are prepared to put it as developer supported. 