### PR TITLE
WIP: [FUSETOOLS2-1131] As a Camel K application developer, when debug connection is not working through contextual menu, i want to have access to `kamel debug` log

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -62,6 +62,15 @@ export async function activate(context: vscode.ExtensionContext) {
 	vscode.debug.registerDebugAdapterTrackerFactory(CAMEL_DEBUG_ADAPTER_ID, {
 		createDebugAdapterTracker(session: vscode.DebugSession) {
 		  return {
+			onError: err => {
+				const outputChannel = vscode.window.createOutputChannel("Camel Debug Adapter Protocol");
+				outputChannel.appendLine(err.message);
+				
+				const cp = require('child_process')
+				cp.exec('kamel debug', (_, stdout: string, _) => {
+					outputChannel.appendLine(stdout);
+				});
+			},
 			onDidSendMessage: m => {
 					if (m.type === 'event'
 						&& m.event === 'output'
@@ -70,7 +79,7 @@ export async function activate(context: vscode.ExtensionContext) {
 							telemetryService.send(m.body?.data);
 					}
 				}
-			};
+			}
 		}
 	});
 	const docSelector: vscode.DocumentSelector = [{


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/FUSETOOLS2-1131

Quite sure this code should work, or at least do something. But I'm unable to get  the debug action failing. I'll resume work as soon as I find a way to get it failing so I can proceed with this.