### PR TITLE
FUSETOOLS2-1926: Migrate VSCode DAP extension readme file to new format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,124 +1,88 @@
-[![Build and Test](https://github.com/camel-tooling/camel-dap-client-vscode/actions/workflows/ci.yaml/badge.svg)](https://github.com/camel-tooling/camel-dap-client-vscode/actions/workflows/ci.yaml)
-[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=camel-tooling_camel-dap-client-vscode&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=camel-tooling_camel-dap-client-vscode)
+<h1 align="center">
+ <img width="125" height="125" src="https://raw.githubusercontent.com/camel-tooling/camel-dap-client-vscode/main/icons/icon128.png">
+ <br>
+ Debug Adapter for Apache Camel
+</h1>
 
-# VS Code Debug Adapter client for Apache Camel
+<p align="center">
+ <a href="https://marketplace.visualstudio.com/items?itemName=redhat.vscode-debug-adapter-apache-camel"><img src="https://img.shields.io/visual-studio-marketplace/v/redhat.vscode-debug-adapter-apache-camel?style=for-the-badge" alt="Marketplace Version"/></a>
+ <a href="https://github.com/camel-tooling/camel-dap-client-vscode/actions/workflows/ci.yaml"><img src="https://img.shields.io/github/actions/workflow/status/camel-tooling/camel-dap-client-vscode/ci.yaml?style=for-the-badge" alt="Main CI"></a>
+ <a href="https://github.com/camel-tooling/camel-dap-client-vscode/blob/main/LICENSE.txt"><img src="https://img.shields.io/github/license/camel-tooling/camel-dap-client-vscode?color=blue&style=for-the-badge" alt="License"/></a>
+ <a href="https://gitter.im/camel-tooling/Lobby"><img src="https://img.shields.io/gitter/room/camel-tooling/Lobby?color=yellow&style=for-the-badge" alt="Gitter"/></a>
+</p><br/>
 
-![A breakpoint hit on a Camel route endpoint and the variables displayed](./docs/images/breakpoint.png)
+<h2 align="center">DAP Client for Visual Studio Code.</h2>
 
-## How to use it
+<p align="center">
+  <a href="#features">Features</a> •
+  <a href="#requirements">Requirements</a> •
+  <a href="#how-to-debug">Example</a> •
+  <a href="https://camel-tooling.github.io/camel-dap-client-vscode/">Documentation</a> •
+  <a href="#issues">Issues</a>  •
+  <a href="#data-and-telemetry">Telemetry</a>
+</p>
 
-### Happy path
+<p align="center">
+This is the <a href="https://code.visualstudio.com/">Visual Studio Code</a> extension that adds <a href="https://camel.apache.org/manual/debugger.html">Camel Debugger</a> power by attaching to a running Camel route written in Java, Yaml or XML DSL.
+</p><br/>
 
-- Ensure `jbang` is available on system command-line
-- Open a Camel route which can be started with JBang
-- Call command Palette (`Ctrl+Alt+P`), and pick command `Start Camel Application with JBang and debug` or click on codelens `Camel Debug with JBang` which appears on top of the file.
-- Wait that the route is started and debugger is connected
-- Put a breakpoint on the Camel route
-- Enjoy!
+<p align="center"><img src="./docs/images/breakpoint.png" alt="A breakpoint hit on a Camel route endpoint and the variables displayed." width="100%"/></p>
 
-![Happy path to start and debug Camel route](./docs/images/singleClickCamelDebugWithJBangWithoutVSCodeConfiguration.gif)
+### Features
 
-### Advanced use cases
-
-#### Use a Debug Launch configuration
-
-- Start a Camel 3.16+ application with `camel-debug` on the classpath
-- In `.vscode/launch.json`, provide this kind of content for a local default JMX connection (which is `service:jmx:rmi:///jndi/rmi://localhost:1099/jmxrmi/camel`):
-
-```json
-  {
-	"version": "0.2.0",
-	"configurations": [
-		{
-			"type": "apache.camel",
-			"request": "attach",
-			"name": "Attach Camel Debugger"
-		}
-	]
-  }
-  ```
-- In `Run and Debug` panel, launch the `Attach Camel Debugger`
-- Put a breakpoint on the Camel route
-- Enjoy!
-
-#### Configuration possibilities of the Debug Launch configuration
-
-In `.vscode/launch.json`, provide this kind of content for a local default JMX connection (which is `service:jmx:rmi:///jndi/rmi://localhost:1099/jmxrmi/camel`):
-
-```json
-  {
-	"version": "0.2.0",
-	"configurations": [
-		{
-			"type": "apache.camel",
-			"request": "attach",
-			"name": "Attach Camel Debugger"
-		}
-	]
-  }
-  ```
-or for a specific JMX Url:
-  ```json
-  {
-	"version": "0.2.0",
-	"configurations": [
-		{
-			"type": "apache.camel",
-			"request": "attach",
-			"name": "Attach Camel Debugger",
-			"attach_jmx_url": "service:jmx:rmi:///jndi/rmi://localhost:1099/jmxrmi/camel"
-		}
-	]
-  }
-  ```
-or for a local connection using PID of the Camel application process:
-  ```json
-  {
-	"version": "0.2.0",
-	"configurations": [
-		{
-			"type": "apache.camel",
-			"request": "attach",
-			"name": "Attach Camel Debugger",
-			"attach_pid": "857136"
-		}
-	]
-  }
-  ```
-
-## Features
-
-- Support use of Camel debugger by attaching to a running Camel route written in Java, Yaml or XML (only `Camel Main` mode for XML) using the JMX Url
-- Support local use of Camel debugger by attaching to a running Camel route written in Java, Yaml or XML (only `Camel Main` mode for XML) using the PID
+- `Camel Main` mode for XML only (It implies that it is not working with Camel context specified in Camel XML file.)
+  - Support use of Camel debugger by attaching to a running Camel route written in Java, Yaml or XML using the JMX Url
+  - Support local use of Camel debugger by attaching to a running Camel route written in Java, Yaml or XML using the PID
 - Support a single Camel context
-- Add/Remove breakpoint
-- Support conditional breakpoint with `simple` language. See [here](https://camel.apache.org/components/latest/languages/simple-language.html) for details on how to write condition with simple language.
+- Add/Remove breakpoints
+- Support conditional breakpoints with `simple` language. See How to write condition with [simple language](https://camel.apache.org/components/latest/languages/simple-language.html) for details.
 - Inspect variable values on suspended breakpoints
 - Resume a single route instance and resume all route instances
 - Stepping when the route definition is in the same file
-- Allow to update values of variables:
+- Allow to update variables:
   - in scope `Debugger`
   - the message body
-  - a message header when it is of type String
-  - an exchange property when it is of type String
+  - a message header of type String
+  - an exchange property of type String
 - Command `Start Camel Application with JBang and debug`. It allows a one-click start and Camel debug in simple cases. This command is available through:
-  - Command Palette. It requires having a valid Camel file opened in editor.
-  - Contextual menu in File explorer. It is visible to all `*.xml`, `*.java`, `*.yaml` and `*.yml`. It is up to the user to ensure it is a Camel route file. The command is also opening the files in editor to be ready to place breakpoints.
+  - Command Palette. It requires a valid Camel file opened in current editor.
+  - Contextual menu in File explorer. It is visible to all `*.xml`, `*.java`, `*.yaml` and `*.yml`.
   - Codelens at the top of a Camel file (the heuristic for the codelens is checking that there is a `from` and a `to` or a `log` on `java`, `xml` and `yaml` files).
 - Configuration snippets for Camel debugger launch configuration
-- Configuration snippets to launch Camel application ready to accept a Camel debugger connection using JBang or Maven with Camel maven plugin or Quarkus Devs
+- Configuration snippets to launch Camel application ready to accept a Camel debugger connection using JBang, Maven with Camel maven plugin or Quarkus Devs
 
-## Requirements
+### Requirements
 
-Java Runtime Environment 11+ with com.sun.tools.attach.VirtualMachine (available in most JVMs such as Hotspot and OpenJDK) must be available on system path.
-
-For some features, [JBang](https://www.jbang.dev/) must be available on command-line.
-
-The Camel instance to debug must follow these requirements:
-  - Camel 3.16+
+- **Java Runtime Environment 11+** with `com.sun.tools.attach.VirtualMachine` (available in most JVMs such as Hotspot and OpenJDK).
+- The Camel instance to debug must follow these requirements:
+  - **Camel 3.16+**
   - Have `camel-debug` on the classpath
-  - Have JMX enabled
+  - Have **JMX enabled**
+- ⚠️ For some features, The [JBang](https://www.jbang.dev/) must be available on a system command-line.
 
-## Usage data
+### How To Debug - example
 
-The Debug Adapter for Apache Camel by Red Hat extension collects anonymous [usage data](USAGE_DATA.md) and sends it to Red Hat servers to help improve our products and services. Read our [privacy statement](https://developers.redhat.com/article/tool-data-collection) to learn more. This extension respects the redhat.telemetry.enabled setting which you can learn more about at https://github.com/redhat-developer/vscode-redhat-telemetry#how-to-disable-telemetry-reporting
+1. Ensure `jbang` is available on system command-line
+2. Open a Camel route which can be started with JBang
+3. Call command Palette (`Ctrl + Alt + P`), and pick command `Start Camel Application with JBang and debug` or click on codelens `Camel Debug with JBang` which appears on top of the file.
+4. Wait until the route is started and debugger is connected
+5. Put a breakpoint on the Camel route
+6. Debug! 🔥
+
+<p align="center"><img src="./docs/images/singleClickCamelDebugWithJBangWithoutVSCodeConfiguration.gif" alt="appy path to start and debug Camel route." width="100%"/></p>
+
+### Documentation
+
+Our full documentation is located in [GitHub pages](https://camel-tooling.github.io/camel-dap-client-vscode/). Included are details about all of DAP Client for Visual Studio Code capabilities with examples and detailed information.
+
+### Issues
+
+Something is not working properly? In that case, feel free to [open issues, add feature requests, report bugs, etc.](https://github.com/camel-tooling/camel-dap-client-vscode/issues)
+
+### Get Involved
+
+If you'd like to help us get better, we appriciate it! Check out our [Contribution Guide](Contributing.md) on how to do that.
+
+### Data and Telemetry
+
+The DAP Client for Visual Studio Code extension collects anonymous [usage data](USAGE_DATA.md) and sends it to Red Hat servers to help improve our products and services. Read our [privacy statement](https://developers.redhat.com/article/tool-data-collection) to learn more. This extension respects the `redhat.telemetry.enabled` setting which you can learn more about at [How to disable telemetry reporting](https://github.com/redhat-developer/vscode-redhat-telemetry#how-to-disable-telemetry-reporting).

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,5 @@
+title: Debug Adapter for Apache Camel by Red Hat
+logo: https://raw.githubusercontent.com/camel-tooling/camel-dap-client-vscode/main/icons/icon128.png
+description: This is the client implementation of the Debug Adapter Server for Apache Camel for Visual Studio Code
+# Used theme https://github.com/pages-themes/minimal
+theme: jekyll-theme-minimal

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="{{ site.lang | default: "en-US" }}">
+  <head>
+    <title></title>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+{% seo %}
+    <link rel="stylesheet" href="{{ "/assets/css/style.css?v=" | append: site.github.build_revision | relative_url }}">
+    <!--[if lt IE 9]>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
+    <![endif]-->
+    {% include head-custom.html %}
+  </head>
+  <body>
+    <div class="wrapper">
+      <header>
+        <h1><a href="{{ "/" | absolute_url }}">{{ site.title | default: site.github.repository_name }}</a></h1>
+
+        {% if site.logo %}
+		  <p>
+			<img src="{{site.logo | relative_url}}" alt="Logo" width="125" height="125" />
+			<br/>
+		  </p>
+        {% endif %}
+
+        <p>{{ site.description | default: site.github.project_tagline }}</p>
+
+        {% if site.github.is_project_page %}
+        <p class="view"><a href="{{ site.github.repository_url }}">View the Project on GitHub <small>{{ site.github.repository_nwo }}</small></a></p>
+        {% endif %}
+
+        {% if site.github.is_user_page %}
+        <p class="view"><a href="{{ site.github.owner_url }}">View My GitHub Profile</a></p>
+        {% endif %}
+
+        {% if site.show_downloads %}
+        <ul class="downloads">
+          <li><a href="{{ site.github.zip_url }}">Download <strong>ZIP File</strong></a></li>
+          <li><a href="{{ site.github.tar_url }}">Download <strong>TAR Ball</strong></a></li>
+          <li><a href="{{ site.github.repository_url }}">View On <strong>GitHub</strong></a></li>
+        </ul>
+        {% endif %}
+      </header>
+      <section>
+
+      {{ content }}
+
+      </section>
+    </div>
+    <script src="{{ "/assets/js/scale.fix.js" | relative_url }}"></script>
+  </body>
+</html>

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -1,0 +1,15 @@
+---
+---
+
+@import "{{ site.theme }}";
+
+.zoom {
+	// padding: 50px;
+	transition: transform .2s; /* Animation */
+	width: 100%;
+	margin: 0 auto;
+}
+
+.zoom:hover {
+	transform: scale(1.5); /* (150% zoom - Note: if the zoom is too large, it will go outside of the viewport) */
+}

--- a/docs/content/advanced.md
+++ b/docs/content/advanced.md
@@ -1,0 +1,72 @@
+# Advanced Configurations
+
+## Use a Debug Launch configuration
+
+### Start a Camel 3.16+ application with `camel-debug` on the classpath
+
+1. In `.vscode/launch.json`, provide this kind of content for a local default JMX connection (which is `service:jmx:rmi:///jndi/rmi://localhost:1099/jmxrmi/camel`):
+2. In the `Run and Debug` panel, launch the `Attach Camel Debugger`
+3. Put a breakpoint on the Camel route
+4. Enjoy!
+
+```json
+{   
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "apache.camel",
+            "request": "attach",
+            "name": "Attach Camel Debugger"
+        }
+    ]
+}
+```
+
+## Configuration possibilities of the Debug Launch configuration
+
+In the `.vscode/launch.json`, provide this kind of content for a local default JMX connection (which is `service:jmx:rmi:///jndi/rmi://localhost:1099/jmxrmi/camel`):
+
+```json
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "apache.camel",
+            "request": "attach",
+            "name": "Attach Camel Debugger"
+        }
+    ]
+}
+```
+
+or for a specific JMX Url
+
+```json
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "apache.camel",
+            "request": "attach",
+            "name": "Attach Camel Debugger",
+            "attach_jmx_url": "service:jmx:rmi:///jndi/rmi://localhost:1099/jmxrmi/camel"
+        }
+    ]
+}
+  ```
+
+or for a local connection using PID of the Camel application process:
+
+```json
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "apache.camel",
+            "request": "attach",
+            "name": "Attach Camel Debugger",
+            "attach_pid": "857136"
+        }
+    ]
+}
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,45 @@
+## Introduction
+
+Welcome to the `vscode-debug-adapter-apache-camel` project created by Red Hat! Here you'll find a description of how to use VS Code extension providing Debug Adapter for Apache Camel.
+
+## Description
+
+This extension adds <a href="https://camel.apache.org/manual/debugger.html">Camel Debugger</a> power by attaching to a running Camel route written in Java, Yaml or XML DSL directly in your Visual Studio Code editor. It is working as a client using the [Microsoft Debug Adapter Protocol](https://microsoft.github.io/debug-adapter-protocol/) which communicates with [Camel Debug Server](https://github.com/camel-tooling/camel-debug-adapter) providing all functionalities.
+
+## How to install
+
+1. You can download **vscode-debug-adapter-apache-camel** extension from the [VS Code Extension Marketplace](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-debug-adapter-apache-camel) and the [Open VSX Registry](https://open-vsx.org/extension/redhat/vscode-debug-adapter-apache-camel).
+2. Debug Adapter for Apache Camel can be also installed directly in the [Microsoft VS Code](https://code.visualstudio.com/).
+
+    **Steps**
+    - Open your VS Code.
+    - In VS Code, select **View > Extensions**.
+    - In the search bar, type `Camel Debug`
+    - Select the **Debug Adapter for Apache Camel** option and then click `Install`.
+
+## Features
+
+- Add/Remove breakpoints
+- Support a single Camel context
+- `Camel Main` mode for XML only
+  - Supports the use of Camel debugger
+  - Supports the local use of Camel debugger
+- Support conditional breakpoint with `simple` language.
+- Inspect variable values on suspended breakpoints
+- Resume a single route instance and resume all route instances
+- Stepping when the route definition is in the same file
+- Allow to update values of variables:
+  - in the `Debugger` scope
+  - the message body
+  - a message header of type String
+  - an exchange property of type String
+- One-click start and Camel debug via command `Start Camel Application with JBang and debug`
+- Configuration snippets for Camel debugger launch configuration
+- Configuration snippets to launch Camel application ready to accept a Camel debugger connection using
+  - JBang
+  - or Maven with Camel maven plugin
+  - or Quarkus Devs
+
+### Advanced
+
+- See [Advanced Configurations](./content/advanced.md) page with configurations examples for advanced use cases.


### PR DESCRIPTION
Signed-off-by: Dominik Jelinek <djelinek@redhat.com>