### PR TITLE
FUSETOOLS2-1744: Provide UI test for commands from context menu

### DIFF
--- a/src/ui-test/tests/context.menu.test.ts
+++ b/src/ui-test/tests/context.menu.test.ts
@@ -2,51 +2,88 @@ import { expect } from 'chai';
 import * as path from 'path';
 import {
     ActivityBar,
+    after,
     before,
+    EditorView,
     SideBarView,
     ViewControl,
-    ViewItem,
+    ViewSection,
     VSBrowser,
+    WebDriver,
 } from 'vscode-extension-tester';
+import {
+    CAMEL_ROUTE_YAML_WITH_SPACE,
+    CAMEL_RUN_ACTION_LABEL,
+    CAMEL_RUN_DEBUG_ACTION_LABEL,
+    DEBUGGER_ATTACHED_MESSAGE,
+    HELLO_CAMEL_MESSAGE,
+    TEST_ARRAY_RUN,
+    TEST_ARRAY_RUN_DEBUG,
+    activateTerminalView,
+    disconnectDebugger,
+    killTerminal,
+    openContextMenu,
+    selectContextMenuItem,
+    waitUntilTerminalHasText
+} from '../utils';
 
 (process.platform === 'darwin' ? describe.skip : describe)('Camel file context menu test', function () {
+    this.timeout(240000);
 
-    const CAMEL_RUN_DEBUG_MENU_ITEM = 'Run Camel Application with JBang and Debug';
-    const CAMEL_RUN_MENU_ITEM = 'Run Camel Application with JBang';
-    const CAMEL_ROUTE_YAML = 'demo route.camel.yaml';
+    let driver: WebDriver;
 
-    let item: ViewItem;
+    before('Before setup', async function () {
+        driver = VSBrowser.instance.driver;
+        await VSBrowser.instance.openResources(path.resolve('src', 'ui-test', 'resources'));
+        await VSBrowser.instance.waitForWorkbench();
 
-    describe('Camel Group items', function () {
-        this.timeout(180000);
+        await (await new ActivityBar().getViewControl('Explorer') as ViewControl).openView();
 
-        before('Before setup', async function () {
-            await VSBrowser.instance.openResources(path.resolve('src', 'ui-test', 'resources'));
-            await VSBrowser.instance.waitForWorkbench();
+        const section = await new SideBarView().getContent().getSection('resources') as ViewSection;
+        await section.openItem(CAMEL_ROUTE_YAML_WITH_SPACE);
 
-            await (await new ActivityBar().getViewControl('Explorer') as ViewControl).openView();
-
-            item = await (await new SideBarView().getContent().getSection('resources')).findItem(CAMEL_ROUTE_YAML) as ViewItem;
-        });
-
-        it('Debug and Run menu item is available', async function () {
-            const menu = await item.openContextMenu();
-            const runAndDebugMenuItem = await menu.hasItem(CAMEL_RUN_DEBUG_MENU_ITEM);
-
-            expect(runAndDebugMenuItem).to.not.undefined;
-
-            await menu.close();
-        });
-
-        it('Run menu item is available', async function () {
-            const menu = await item.openContextMenu();
-            const runItem = await menu.hasItem(CAMEL_RUN_MENU_ITEM);
-
-            expect(runItem).to.not.undefined;
-
-            await menu.close();
-        });
-
+        await driver.wait(async function () {
+            return (await new EditorView().getOpenEditorTitles()).find(title => title === CAMEL_ROUTE_YAML_WITH_SPACE);
+        }, 5000);
     });
 
+    after('After cleanup', async function () {
+        await new EditorView().closeAllEditors();
+    });
+
+    it('Debug and Run menu item is available', async function () {
+        const menu = await openContextMenu(CAMEL_ROUTE_YAML_WITH_SPACE);
+        const runAndDebugMenuItem = await menu.hasItem(CAMEL_RUN_DEBUG_ACTION_LABEL);
+
+        expect(runAndDebugMenuItem).to.not.undefined;
+
+        await menu.close();
+    });
+
+    it('Run menu item is available', async function () {
+        const menu = await openContextMenu(CAMEL_ROUTE_YAML_WITH_SPACE);
+        const runItem = await menu.hasItem(CAMEL_RUN_ACTION_LABEL);
+
+        expect(runItem).to.not.undefined;
+
+        await menu.close();
+    });
+
+    it(`Execute command '${CAMEL_RUN_ACTION_LABEL}' in context menu`, async function () {
+        await selectContextMenuItem(CAMEL_RUN_ACTION_LABEL, await openContextMenu(CAMEL_ROUTE_YAML_WITH_SPACE));
+        await waitUntilTerminalHasText(driver, TEST_ARRAY_RUN);
+        expect(await (await activateTerminalView()).getText()).to.contain(HELLO_CAMEL_MESSAGE);
+        await killTerminal();
+    });
+
+    it(`Execute command '${CAMEL_RUN_DEBUG_ACTION_LABEL}' in context menu`, async function () {
+        await selectContextMenuItem(CAMEL_RUN_DEBUG_ACTION_LABEL, await openContextMenu(CAMEL_ROUTE_YAML_WITH_SPACE));
+        await waitUntilTerminalHasText(driver, TEST_ARRAY_RUN_DEBUG);
+        const terminalLog = await (await activateTerminalView()).getText();
+        expect(terminalLog).to.contain(DEBUGGER_ATTACHED_MESSAGE);
+        expect(terminalLog).to.contain(HELLO_CAMEL_MESSAGE);
+        await (await new ActivityBar().getViewControl('Run and Debug') as ViewControl).closeView();
+        await disconnectDebugger(driver);
+        await killTerminal();
+    });
 });

--- a/src/ui-test/utils.ts
+++ b/src/ui-test/utils.ts
@@ -1,8 +1,12 @@
 import {
     BottomBarPanel,
+    ContextMenu,
+    ContextMenuItem,
     DebugToolbar,
     InputBox,
+    SideBarView,
     TerminalView,
+    ViewItem,
     WebDriver,
     Workbench,
     until
@@ -43,6 +47,33 @@ export async function executeCommand(command: string): Promise<void> {
         }
     }
     throw new Error(`Command '${command}' not found in the command palette`);
+}
+
+/**
+ * Opens the context menu for a given route in the sidebar.
+ * @param route The route for which the context menu should be opened.
+ * @returns A promise that resolves to the opened ContextMenu.
+ */
+export async function openContextMenu(route: string): Promise<ContextMenu> {
+    const item = await (await new SideBarView().getContent().getSection('resources')).findItem(route) as ViewItem;
+    const menu = await item.openContextMenu();
+    return menu;
+}
+
+/**
+ * Selects a specific command from a given context menu.
+ * @param command The command to select from the context menu.
+ * @param menu The ContextMenu instance from which to select the command.
+ * @returns A promise that resolves once the command is selected.
+ * @throws An error if the specified command is not found in the context menu.
+ */
+export async function selectContextMenuItem(command: string, menu: ContextMenu): Promise<void> {
+    const button = await menu.getItem(command);
+    if (button instanceof ContextMenuItem) {
+        await button.select();
+    } else {
+        throw new Error(`Button ${command} not found in context menu`);
+    }
 }
 
 /**


### PR DESCRIPTION
Will work after https://github.com/camel-tooling/camel-dap-client-vscode/pull/389

Relates:

- [FUSETOOLS2-1744](https://issues.redhat.com/browse/FUSETOOLS2-1744)