### PR TITLE
Add minor updates in ui-tests 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,8 +31,7 @@
 				"mocha-jenkins-reporter": "^0.4.8",
 				"mvn-artifact-download": "^6.1.1",
 				"typescript": "^5.1.3",
-				"vscode-extension-tester": "^5.7.1",
-				"vscode-uitests-tooling": "^3.0.1"
+				"vscode-uitests-tooling": "^4.0.1"
 			},
 			"engines": {
 				"vscode": "^1.76.0"
@@ -462,9 +461,9 @@
 			}
 		},
 		"node_modules/@types/selenium-webdriver": {
-			"version": "4.1.13",
-			"resolved": "https://registry.npmjs.org/@types/selenium-webdriver/-/selenium-webdriver-4.1.13.tgz",
-			"integrity": "sha512-kGpIh7bvu4HGCJXl4PEJ53kzpG4iXlRDd66SNNCfJ58QhFuk9skOm57lVffZap5ChEOJwbge/LJ9IVGVC8EEOg==",
+			"version": "4.1.15",
+			"resolved": "https://registry.npmjs.org/@types/selenium-webdriver/-/selenium-webdriver-4.1.15.tgz",
+			"integrity": "sha512-oQ15G3q3EZ0dS049SB/5zx2tQkIS2kmDQWC/TSfAHJYKvXLZoUiLaPXnfSwbLP8Q5lcJeu5oYjKVSEV0t3H6Bg==",
 			"dev": true,
 			"dependencies": {
 				"@types/ws": "*"
@@ -1078,13 +1077,30 @@
 			}
 		},
 		"node_modules/bl": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
-			"integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+			"integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
 			"dev": true,
+			"optional": true,
 			"dependencies": {
-				"readable-stream": "^2.3.5",
-				"safe-buffer": "^5.1.1"
+				"buffer": "^5.5.0",
+				"inherits": "^2.0.4",
+				"readable-stream": "^3.4.0"
+			}
+		},
+		"node_modules/bl/node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"dev": true,
+			"optional": true,
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/bluebird": {
@@ -1211,9 +1227,9 @@
 			}
 		},
 		"node_modules/cacheable-request": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.2.tgz",
-			"integrity": "sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==",
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+			"integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
 			"dev": true,
 			"dependencies": {
 				"clone-response": "^1.0.2",
@@ -2613,9 +2629,9 @@
 			}
 		},
 		"node_modules/graceful-fs": {
-			"version": "4.2.10",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-			"integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
 			"dev": true
 		},
 		"node_modules/grapheme-splitter": {
@@ -2725,9 +2741,9 @@
 			}
 		},
 		"node_modules/http-cache-semantics": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-			"integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+			"integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
 			"dev": true
 		},
 		"node_modules/http-proxy-agent": {
@@ -3398,10 +3414,13 @@
 			}
 		},
 		"node_modules/minimist": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-			"dev": true
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/minipass": {
 			"version": "6.0.2",
@@ -3413,12 +3432,12 @@
 			}
 		},
 		"node_modules/mkdirp": {
-			"version": "0.5.5",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+			"version": "0.5.6",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+			"integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
 			"dev": true,
 			"dependencies": {
-				"minimist": "^1.2.5"
+				"minimist": "^1.2.6"
 			},
 			"bin": {
 				"mkdirp": "bin/cmd.js"
@@ -4086,63 +4105,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/prebuild-install/node_modules/bl": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-			"integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-			"dev": true,
-			"optional": true,
-			"dependencies": {
-				"buffer": "^5.5.0",
-				"inherits": "^2.0.4",
-				"readable-stream": "^3.4.0"
-			}
-		},
-		"node_modules/prebuild-install/node_modules/readable-stream": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-			"dev": true,
-			"optional": true,
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/prebuild-install/node_modules/tar-fs": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-			"integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-			"dev": true,
-			"optional": true,
-			"dependencies": {
-				"chownr": "^1.1.1",
-				"mkdirp-classic": "^0.5.2",
-				"pump": "^3.0.0",
-				"tar-stream": "^2.1.4"
-			}
-		},
-		"node_modules/prebuild-install/node_modules/tar-stream": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-			"integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-			"dev": true,
-			"optional": true,
-			"dependencies": {
-				"bl": "^4.0.3",
-				"end-of-stream": "^1.4.1",
-				"fs-constants": "^1.0.0",
-				"inherits": "^2.0.3",
-				"readable-stream": "^3.1.1"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/prelude-ls": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -4682,6 +4644,80 @@
 			}
 		},
 		"node_modules/tar-fs": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+			"integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+			"dev": true,
+			"optional": true,
+			"dependencies": {
+				"chownr": "^1.1.1",
+				"mkdirp-classic": "^0.5.2",
+				"pump": "^3.0.0",
+				"tar-stream": "^2.1.4"
+			}
+		},
+		"node_modules/tar-stream": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+			"integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+			"dev": true,
+			"optional": true,
+			"dependencies": {
+				"bl": "^4.0.3",
+				"end-of-stream": "^1.4.1",
+				"fs-constants": "^1.0.0",
+				"inherits": "^2.0.3",
+				"readable-stream": "^3.1.1"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/tar-stream/node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"dev": true,
+			"optional": true,
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/targz": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/targz/-/targz-1.0.1.tgz",
+			"integrity": "sha512-6q4tP9U55mZnRuMTBqnqc3nwYQY3kv+QthCFZuMk+Tn1qYUnMPmL/JZ/mzgXINzFpSqfU+242IFmFU9VPvqaQw==",
+			"dev": true,
+			"dependencies": {
+				"tar-fs": "^1.8.1"
+			}
+		},
+		"node_modules/targz/node_modules/bl": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
+			"integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
+			"dev": true,
+			"dependencies": {
+				"readable-stream": "^2.3.5",
+				"safe-buffer": "^5.1.1"
+			}
+		},
+		"node_modules/targz/node_modules/pump": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+			"integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+			"dev": true,
+			"dependencies": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
+		},
+		"node_modules/targz/node_modules/tar-fs": {
 			"version": "1.16.3",
 			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
 			"integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
@@ -4693,17 +4729,7 @@
 				"tar-stream": "^1.1.2"
 			}
 		},
-		"node_modules/tar-fs/node_modules/pump": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
-			"integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
-			"dev": true,
-			"dependencies": {
-				"end-of-stream": "^1.1.0",
-				"once": "^1.3.1"
-			}
-		},
-		"node_modules/tar-stream": {
+		"node_modules/targz/node_modules/tar-stream": {
 			"version": "1.6.2",
 			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
 			"integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
@@ -4719,15 +4745,6 @@
 			},
 			"engines": {
 				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/targz": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/targz/-/targz-1.0.1.tgz",
-			"integrity": "sha512-6q4tP9U55mZnRuMTBqnqc3nwYQY3kv+QthCFZuMk+Tn1qYUnMPmL/JZ/mzgXINzFpSqfU+242IFmFU9VPvqaQw==",
-			"dev": true,
-			"dependencies": {
-				"tar-fs": "^1.8.1"
 			}
 		},
 		"node_modules/text-table": {
@@ -5080,9 +5097,9 @@
 			}
 		},
 		"node_modules/vscode-uitests-tooling": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/vscode-uitests-tooling/-/vscode-uitests-tooling-3.0.1.tgz",
-			"integrity": "sha512-4NE6iAZpKqFrODTxyidDwcP528wTPxgHnDx+4hiPMrmgUiMUoWNushjnaK/+LWqvSFG6AjJvbws0+K1Dbl1egg==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/vscode-uitests-tooling/-/vscode-uitests-tooling-4.0.1.tgz",
+			"integrity": "sha512-ZZI3zMtbCb6ZoakAt8aFTHHsN1w1aT0/V/2xfmHKHH2JfU52XSo4OMPPoFpAWqF59oYvqt0NMX7fPpMHYT8EhQ==",
 			"dev": true,
 			"dependencies": {
 				"chai": "^4.3.7",
@@ -5090,7 +5107,7 @@
 				"fs-extra": "^11.1.1",
 				"sanitize-filename": "^1.6.3",
 				"tree-kill": "^1.2.2",
-				"vscode-extension-tester": "^5.6.0"
+				"vscode-extension-tester": "^5.7.1"
 			},
 			"peerDependencies": {
 				"mocha": ">=5.2.0"
@@ -5663,9 +5680,9 @@
 			}
 		},
 		"@types/selenium-webdriver": {
-			"version": "4.1.13",
-			"resolved": "https://registry.npmjs.org/@types/selenium-webdriver/-/selenium-webdriver-4.1.13.tgz",
-			"integrity": "sha512-kGpIh7bvu4HGCJXl4PEJ53kzpG4iXlRDd66SNNCfJ58QhFuk9skOm57lVffZap5ChEOJwbge/LJ9IVGVC8EEOg==",
+			"version": "4.1.15",
+			"resolved": "https://registry.npmjs.org/@types/selenium-webdriver/-/selenium-webdriver-4.1.15.tgz",
+			"integrity": "sha512-oQ15G3q3EZ0dS049SB/5zx2tQkIS2kmDQWC/TSfAHJYKvXLZoUiLaPXnfSwbLP8Q5lcJeu5oYjKVSEV0t3H6Bg==",
 			"dev": true,
 			"requires": {
 				"@types/ws": "*"
@@ -6077,13 +6094,29 @@
 			"dev": true
 		},
 		"bl": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
-			"integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+			"integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
 			"dev": true,
+			"optional": true,
 			"requires": {
-				"readable-stream": "^2.3.5",
-				"safe-buffer": "^5.1.1"
+				"buffer": "^5.5.0",
+				"inherits": "^2.0.4",
+				"readable-stream": "^3.4.0"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.6.2",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+					"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
 			}
 		},
 		"bluebird": {
@@ -6181,9 +6214,9 @@
 			"dev": true
 		},
 		"cacheable-request": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.2.tgz",
-			"integrity": "sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==",
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+			"integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
 			"dev": true,
 			"requires": {
 				"clone-response": "^1.0.2",
@@ -7213,9 +7246,9 @@
 			}
 		},
 		"graceful-fs": {
-			"version": "4.2.10",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-			"integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
 			"dev": true
 		},
 		"grapheme-splitter": {
@@ -7291,9 +7324,9 @@
 			}
 		},
 		"http-cache-semantics": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-			"integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+			"integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
 			"dev": true
 		},
 		"http-proxy-agent": {
@@ -7788,9 +7821,9 @@
 			}
 		},
 		"minimist": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
 			"dev": true
 		},
 		"minipass": {
@@ -7800,12 +7833,12 @@
 			"dev": true
 		},
 		"mkdirp": {
-			"version": "0.5.5",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+			"version": "0.5.6",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+			"integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
 			"dev": true,
 			"requires": {
-				"minimist": "^1.2.5"
+				"minimist": "^1.2.6"
 			}
 		},
 		"mkdirp-classic": {
@@ -8295,59 +8328,6 @@
 				"simple-get": "^4.0.0",
 				"tar-fs": "^2.0.0",
 				"tunnel-agent": "^0.6.0"
-			},
-			"dependencies": {
-				"bl": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-					"integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"buffer": "^5.5.0",
-						"inherits": "^2.0.4",
-						"readable-stream": "^3.4.0"
-					}
-				},
-				"readable-stream": {
-					"version": "3.6.2",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-					"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"inherits": "^2.0.3",
-						"string_decoder": "^1.1.1",
-						"util-deprecate": "^1.0.1"
-					}
-				},
-				"tar-fs": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-					"integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"chownr": "^1.1.1",
-						"mkdirp-classic": "^0.5.2",
-						"pump": "^3.0.0",
-						"tar-stream": "^2.1.4"
-					}
-				},
-				"tar-stream": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-					"integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"bl": "^4.0.3",
-						"end-of-stream": "^1.4.1",
-						"fs-constants": "^1.0.0",
-						"inherits": "^2.0.3",
-						"readable-stream": "^3.1.1"
-					}
-				}
 			}
 		},
 		"prelude-ls": {
@@ -8729,42 +8709,44 @@
 			}
 		},
 		"tar-fs": {
-			"version": "1.16.3",
-			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
-			"integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+			"integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
 			"dev": true,
+			"optional": true,
 			"requires": {
-				"chownr": "^1.0.1",
-				"mkdirp": "^0.5.1",
-				"pump": "^1.0.0",
-				"tar-stream": "^1.1.2"
-			},
-			"dependencies": {
-				"pump": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
-					"integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
-					"dev": true,
-					"requires": {
-						"end-of-stream": "^1.1.0",
-						"once": "^1.3.1"
-					}
-				}
+				"chownr": "^1.1.1",
+				"mkdirp-classic": "^0.5.2",
+				"pump": "^3.0.0",
+				"tar-stream": "^2.1.4"
 			}
 		},
 		"tar-stream": {
-			"version": "1.6.2",
-			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
-			"integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+			"integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
 			"dev": true,
+			"optional": true,
 			"requires": {
-				"bl": "^1.0.0",
-				"buffer-alloc": "^1.2.0",
-				"end-of-stream": "^1.0.0",
+				"bl": "^4.0.3",
+				"end-of-stream": "^1.4.1",
 				"fs-constants": "^1.0.0",
-				"readable-stream": "^2.3.0",
-				"to-buffer": "^1.1.1",
-				"xtend": "^4.0.0"
+				"inherits": "^2.0.3",
+				"readable-stream": "^3.1.1"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.6.2",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+					"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
 			}
 		},
 		"targz": {
@@ -8774,6 +8756,55 @@
 			"dev": true,
 			"requires": {
 				"tar-fs": "^1.8.1"
+			},
+			"dependencies": {
+				"bl": {
+					"version": "1.2.3",
+					"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
+					"integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
+					"dev": true,
+					"requires": {
+						"readable-stream": "^2.3.5",
+						"safe-buffer": "^5.1.1"
+					}
+				},
+				"pump": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+					"integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+					"dev": true,
+					"requires": {
+						"end-of-stream": "^1.1.0",
+						"once": "^1.3.1"
+					}
+				},
+				"tar-fs": {
+					"version": "1.16.3",
+					"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
+					"integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
+					"dev": true,
+					"requires": {
+						"chownr": "^1.0.1",
+						"mkdirp": "^0.5.1",
+						"pump": "^1.0.0",
+						"tar-stream": "^1.1.2"
+					}
+				},
+				"tar-stream": {
+					"version": "1.6.2",
+					"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
+					"integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
+					"dev": true,
+					"requires": {
+						"bl": "^1.0.0",
+						"buffer-alloc": "^1.2.0",
+						"end-of-stream": "^1.0.0",
+						"fs-constants": "^1.0.0",
+						"readable-stream": "^2.3.0",
+						"to-buffer": "^1.1.1",
+						"xtend": "^4.0.0"
+					}
+				}
 			}
 		},
 		"text-table": {
@@ -9045,9 +9076,9 @@
 			"requires": {}
 		},
 		"vscode-uitests-tooling": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/vscode-uitests-tooling/-/vscode-uitests-tooling-3.0.1.tgz",
-			"integrity": "sha512-4NE6iAZpKqFrODTxyidDwcP528wTPxgHnDx+4hiPMrmgUiMUoWNushjnaK/+LWqvSFG6AjJvbws0+K1Dbl1egg==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/vscode-uitests-tooling/-/vscode-uitests-tooling-4.0.1.tgz",
+			"integrity": "sha512-ZZI3zMtbCb6ZoakAt8aFTHHsN1w1aT0/V/2xfmHKHH2JfU52XSo4OMPPoFpAWqF59oYvqt0NMX7fPpMHYT8EhQ==",
 			"dev": true,
 			"requires": {
 				"chai": "^4.3.7",
@@ -9055,7 +9086,7 @@
 				"fs-extra": "^11.1.1",
 				"sanitize-filename": "^1.6.3",
 				"tree-kill": "^1.2.2",
-				"vscode-extension-tester": "^5.6.0"
+				"vscode-extension-tester": "^5.7.1"
 			}
 		},
 		"webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -234,8 +234,7 @@
 		"mocha-jenkins-reporter": "^0.4.8",
 		"mvn-artifact-download": "^6.1.1",
 		"typescript": "^5.1.3",
-		"vscode-extension-tester": "^5.7.1",
-		"vscode-uitests-tooling": "^3.0.1"
+		"vscode-uitests-tooling": "^4.0.1"
 	},
 	"dependencies": {
 		"@redhat-developer/vscode-redhat-telemetry": "^0.6.1",

--- a/src/ui-test/tests/command.palette.test.ts
+++ b/src/ui-test/tests/command.palette.test.ts
@@ -5,8 +5,6 @@ import {
     before,
     EditorView,
     SideBarView,
-    ViewControl,
-    ViewSection,
     VSBrowser,
     WebDriver,
 } from 'vscode-uitests-tooling';
@@ -31,21 +29,20 @@ describe('JBang commands execution through command palette', function () {
 
     let driver: WebDriver;
 
-    before('Before setup', async function () {
+    before(async function () {
         driver = VSBrowser.instance.driver;
     });
 
-    after('After cleanup', async function () {
+    after(async function () {
         await new EditorView().closeAllEditors();
     });
 
-    beforeEach('Before each test', async function () {
+    beforeEach(async function () {
         await VSBrowser.instance.openResources(path.resolve('src', 'ui-test', 'resources'));
-        await VSBrowser.instance.waitForWorkbench();
 
-        await (await new ActivityBar().getViewControl('Explorer') as ViewControl).openView();
+        await (await new ActivityBar().getViewControl('Explorer')).openView();
 
-        const section = await new SideBarView().getContent().getSection('resources') as ViewSection;
+        const section = await new SideBarView().getContent().getSection('resources');
         await section.openItem(CAMEL_ROUTE_YAML_WITH_SPACE);
 
         const editorView = new EditorView();
@@ -54,7 +51,7 @@ describe('JBang commands execution through command palette', function () {
         }, 5000);
     });
 
-    afterEach('After each test', async function () {
+    afterEach(async function () {
         await killTerminal();
     });
 
@@ -71,6 +68,6 @@ describe('JBang commands execution through command palette', function () {
         expect(terminalLog).to.contain(DEBUGGER_ATTACHED_MESSAGE);
         expect(terminalLog).to.contain(HELLO_CAMEL_MESSAGE);
         await disconnectDebugger(driver);
-        await (await new ActivityBar().getViewControl('Run and Debug') as ViewControl).closeView();
+        await (await new ActivityBar().getViewControl('Run and Debug')).closeView();
     });
 });

--- a/src/ui-test/tests/context.menu.test.ts
+++ b/src/ui-test/tests/context.menu.test.ts
@@ -6,11 +6,9 @@ import {
     before,
     EditorView,
     SideBarView,
-    ViewControl,
-    ViewSection,
     VSBrowser,
     WebDriver,
-} from 'vscode-extension-tester';
+} from 'vscode-uitests-tooling';
 import {
     CAMEL_ROUTE_YAML_WITH_SPACE,
     CAMEL_RUN_ACTION_LABEL,
@@ -32,14 +30,13 @@ import {
 
     let driver: WebDriver;
 
-    before('Before setup', async function () {
+    before(async function () {
         driver = VSBrowser.instance.driver;
         await VSBrowser.instance.openResources(path.resolve('src', 'ui-test', 'resources'));
-        await VSBrowser.instance.waitForWorkbench();
 
-        await (await new ActivityBar().getViewControl('Explorer') as ViewControl).openView();
+        await (await new ActivityBar().getViewControl('Explorer')).openView();
 
-        const section = await new SideBarView().getContent().getSection('resources') as ViewSection;
+        const section = await new SideBarView().getContent().getSection('resources');
         await section.openItem(CAMEL_ROUTE_YAML_WITH_SPACE);
 
         await driver.wait(async function () {
@@ -47,7 +44,7 @@ import {
         }, 5000);
     });
 
-    after('After cleanup', async function () {
+    after(async function () {
         await new EditorView().closeAllEditors();
     });
 
@@ -82,7 +79,7 @@ import {
         const terminalLog = await (await activateTerminalView()).getText();
         expect(terminalLog).to.contain(DEBUGGER_ATTACHED_MESSAGE);
         expect(terminalLog).to.contain(HELLO_CAMEL_MESSAGE);
-        await (await new ActivityBar().getViewControl('Run and Debug') as ViewControl).closeView();
+        await (await new ActivityBar().getViewControl('Run and Debug')).closeView();
         await disconnectDebugger(driver);
         await killTerminal();
     });

--- a/src/ui-test/tests/debugger.test.ts
+++ b/src/ui-test/tests/debugger.test.ts
@@ -7,7 +7,6 @@ import {
     SideBarView,
     TextEditor,
     VSBrowser,
-    ViewSection,
     WebDriver
 } from "vscode-uitests-tooling";
 import {
@@ -24,18 +23,18 @@ import {
 } from '../utils';
 
 describe('Camel Debugger tests', function () {
-    this.timeout(240000);
+    this.timeout(300000);
 
     let driver: WebDriver;
 
-    before('Before setup', async function () {
+    before(async function () {
         driver = VSBrowser.instance.driver;
 
         await VSBrowser.instance.openResources(path.resolve('src', 'ui-test', 'resources'));
 
         await (await new ActivityBar().getViewControl('Explorer')).openView();
 
-        const section = await new SideBarView().getContent().getSection('resources') as ViewSection;
+        const section = await new SideBarView().getContent().getSection('resources');
         await section.openItem(CAMEL_ROUTE_YAML_WITH_SPACE);
 
         const editorView = new EditorView();
@@ -44,7 +43,7 @@ describe('Camel Debugger tests', function () {
         }, 5000);
     });
 
-    after('After cleanup', async function () {
+    after(async function () {
         await driver.wait(async function () {
             return !await new TextEditor().toggleBreakpoint(11);
         }, 5000);
@@ -62,9 +61,9 @@ describe('Camel Debugger tests', function () {
         }, 5000);
 
         // WORKAROUND: https://github.com/redhat-developer/vscode-extension-tester/issues/402
+        const debugView = (await (await new ActivityBar().getViewControl('Run')).openView()) as DebugView;
         await driver.wait(async function () {
             try {
-                const debugView = (await (await new ActivityBar().getViewControl('Run')).openView()) as DebugView;
                 const variables = await debugView.getContent().getSection('Variables');
                 const messages = await variables.openItem('Message');
                 for await (let message of messages) {
@@ -81,7 +80,7 @@ describe('Camel Debugger tests', function () {
                 // Issue is similar to https://issues.redhat.com/browse/FUSETOOLS2-2100
                 await driver.actions().click().perform();
             }
-        }, 180000, undefined, 500);
+        }, 240000, undefined, 500);
 
         await waitUntilTerminalHasText(driver, [HELLO_WORLD_MESSAGE]);
         expect(await (await activateTerminalView()).getText()).to.contain(HELLO_WORLD_MESSAGE);

--- a/src/ui-test/tests/editor.actions.test.ts
+++ b/src/ui-test/tests/editor.actions.test.ts
@@ -7,8 +7,6 @@ import {
     BottomBarPanel,
     EditorView,
     SideBarView,
-    ViewControl,
-    ViewSection,
     VSBrowser,
     WebDriver,
     WebElement,
@@ -35,14 +33,13 @@ describe('Camel file editor test', function () {
         let editorView: EditorView;
         let bottomBar: BottomBarPanel;
 
-        before('Before setup', async function () {
+        before(async function () {
             driver = VSBrowser.instance.driver;
             await VSBrowser.instance.openResources(path.resolve('src', 'ui-test', 'resources'));
-            await VSBrowser.instance.waitForWorkbench();
 
-            await (await new ActivityBar().getViewControl('Explorer') as ViewControl).openView();
+            await (await new ActivityBar().getViewControl('Explorer')).openView();
 
-            const section = await new SideBarView().getContent().getSection('resources') as ViewSection;
+            const section = await new SideBarView().getContent().getSection('resources');
             await section.openItem(CAMEL_ROUTE_YAML_WITH_SPACE);
 
             editorView = new EditorView();
@@ -54,7 +51,7 @@ describe('Camel file editor test', function () {
             bottomBar.toggle(true);
         });
 
-        after('After cleanup', async function () {
+        after(async function () {
             await editorView.closeAllEditors();
             await bottomBar.toggle(false);
         });
@@ -90,7 +87,7 @@ describe('Camel file editor test', function () {
             expect(terminalLog).to.contain(DEBUGGER_ATTACHED_MESSAGE);
             expect(terminalLog).to.contain(HELLO_CAMEL_MESSAGE);
 
-            await (await new ActivityBar().getViewControl('Run and Debug') as ViewControl).closeView();
+            await (await new ActivityBar().getViewControl('Run and Debug')).closeView();
             await disconnectDebugger(driver);
             await killTerminal();
         });

--- a/src/ui-test/tests/install.test.ts
+++ b/src/ui-test/tests/install.test.ts
@@ -14,9 +14,9 @@ import {
     InputBox,
     SideBarView,
     ViewControl,
-    VSBrowser
-} from 'vscode-extension-tester';
-import { Workbench } from 'vscode-uitests-tooling';
+    VSBrowser,
+    Workbench
+} from 'vscode-uitests-tooling';
 
 describe('Install test', function () {
     this.timeout(30000);
@@ -64,7 +64,6 @@ describe('Install test', function () {
 
         before('Open file before tests', async function () {
             await VSBrowser.instance.openResources(path.resolve('src', 'ui-test', 'resources', CAMEL_ROUTE_YAML));
-            await VSBrowser.instance.waitForWorkbench();
         });
 
         after('Cleanup after tests', async function () {

--- a/src/ui-test/tests/reload.test.ts
+++ b/src/ui-test/tests/reload.test.ts
@@ -5,8 +5,6 @@ import {
     before,
     EditorView,
     SideBarView,
-    ViewControl,
-    ViewSection,
     VSBrowser,
     WebDriver,
     resources,
@@ -28,12 +26,12 @@ import {
 import { expect } from 'chai';
 
 describe('Jbang commands with automatic reload', function () {
-    this.timeout(240000);
+    this.timeout(300000);
 
     let driver: WebDriver;
     let resourceManager: resources.IResourceManager;
 
-    before('Before setup', async function () {
+    before(async function () {
         driver = VSBrowser.instance.driver;
 
         resourceManager = resources.createResourceManager(
@@ -44,11 +42,10 @@ describe('Jbang commands with automatic reload', function () {
         await resourceManager.copy(CAMEL_ROUTE_YAML_WITH_SPACE, CAMEL_ROUTE_YAML_WITH_SPACE_COPY);
 
         await VSBrowser.instance.openResources(path.resolve('src', 'ui-test', 'resources'));
-        await VSBrowser.instance.waitForWorkbench();
 
-        await (await new ActivityBar().getViewControl('Explorer') as ViewControl).openView();
+        await (await new ActivityBar().getViewControl('Explorer')).openView();
 
-        const section = await new SideBarView().getContent().getSection('resources') as ViewSection;
+        const section = await new SideBarView().getContent().getSection('resources');
         await section.openItem(CAMEL_ROUTE_YAML_WITH_SPACE_COPY);
 
         const editorView = new EditorView();
@@ -57,12 +54,12 @@ describe('Jbang commands with automatic reload', function () {
         }, 5000);
     });
 
-    after('After cleanup', async function () {
+    after(async function () {
         await new EditorView().closeAllEditors();
-        await resourceManager.deleteFromResources(CAMEL_ROUTE_YAML_WITH_SPACE_COPY);
+        await resourceManager.delete(CAMEL_ROUTE_YAML_WITH_SPACE_COPY);
     });
 
-    afterEach('After each test', async function () {
+    afterEach(async function () {
         await killTerminal();
     });
 
@@ -70,7 +67,7 @@ describe('Jbang commands with automatic reload', function () {
         await executeCommand(CAMEL_RUN_ACTION_LABEL);
         await waitUntilTerminalHasText(driver, TEST_ARRAY_RUN);
 
-        await driver.wait(async () => { return await replaceTextInCodeEditor(HELLO_CAMEL_MESSAGE, HELLO_WORLD_MESSAGE); });
+        await driver.wait(async () => { return await replaceTextInCodeEditor(HELLO_CAMEL_MESSAGE, HELLO_WORLD_MESSAGE); }, 60000);
         await waitUntilTerminalHasText(driver, [HELLO_WORLD_MESSAGE]);
 
         expect(await (await activateTerminalView()).getText()).to.contain(HELLO_WORLD_MESSAGE);

--- a/src/ui-test/utils.ts
+++ b/src/ui-test/utils.ts
@@ -99,7 +99,7 @@ export async function waitUntilTerminalHasText(driver: WebDriver, textArray: str
         } catch (err) {
             return false;
         }
-    }, undefined, undefined, interval);
+    }, 220000, undefined, interval);
 }
 
 /**
@@ -118,9 +118,10 @@ export async function disconnectDebugger(driver: WebDriver, interval = 500): Pro
         try {
             const debugBar = await DebugToolbar.create();
             await debugBar.disconnect();
-            await driver.wait(until.elementIsNotVisible(debugBar));
+            await driver.wait(until.elementIsNotVisible(debugBar), 10000);
             return true;
         } catch (err) {
+            // Extra click to avoid the error: "Element is not clickable at point (x, y)"
             // Workaround for the issue: https://issues.redhat.com/browse/FUSETOOLS2-2100 
             await driver.actions().click().perform();
             return false;
@@ -145,8 +146,8 @@ export async function activateTerminalView(): Promise<TerminalView> {
  * @returns A boolean indicating whether the text replacement was successful.
  */
 export async function replaceTextInCodeEditor(text: string, replacement: string): Promise<boolean> {
+    const editor = new TextEditor();
     try {
-        const editor = new TextEditor();
         await editor.selectText(text);
         await editor.typeText(replacement);
         await editor.save();


### PR DESCRIPTION
- Camel Debugger tests -> increase the timeout by 1 minute (based on timeout issues during tests on macOS)
- Jbang commands with automatic reload' ->  increase the timeout by 1 minute  (based on timeout issues during tests on macOS)
- Add timeout for `driver.wait` in function `waitUntilTerminalHasText` (as discussed with @mlorinc here -> https://github.com/camel-tooling/camel-dap-client-vscode/pull/407)
- Add timeout for `driver.wait` with `replaceTextInCodeEditor` (same reason^)
- Delete after/before all/each description -> tests are failed to make screenshot with after/before all/each descriptions. example: [gh_action](https://github.com/camel-tooling/camel-dap-client-vscode/actions/runs/5197356242/jobs/9372997610) , error: `Error: Artifact path is not valid: /Camel file editor test.Camel Actions.'after all' hook: After cleanup for 'Can execute 'Run Camel Application with JBang and Debug' action'.png. Contains the following character:  Colon :`
- Change extester on vscode-uitests-tooling in imports (init. extester package uninstall)
- Delete not needed `as View...`

Hope it will stabilize tests a bit more 

Flay issues:

1) Reload -> Solved
~~Flaky issue exists on MacOS -> `await editor.selectText(text)`~~
~~`Error: NoSuchElementError: no such element: Unable to locate element: {"method":"css selector","selector":".monaco-menu"}`~~
~~Should be fixed with new release of extester (vscode-uitests-tooling)~~

2) Debugger -> Flaky but maybe because of the extension, sometimes debugger seems is not attached  correctly (https://github.com/camel-tooling/camel-dap-client-vscode/actions/runs/5211701261/jobs/9404322203)

![Camel Debugger tests Update of a value with Camel debugger](https://github.com/camel-tooling/camel-dap-client-vscode/assets/46084942/ebbb9216-c5d1-4c84-b487-ad02cf39cac5)

```
  1) Camel Debugger tests
       Update of a value with Camel debugger:
     TimeoutError: Wait timed out after 240076ms
      at /Users/runner/work/camel-dap-client-vscode/camel-dap-client-vscode/node_modules/selenium-webdriver/lib/webdriver.js:929:17
      at runMicrotasks (<anonymous>)
      at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

3) Install test -> Sometimes happens (https://github.com/camel-tooling/camel-dap-client-vscode/actions/runs/5211701261/jobs/9404620692)

![Install test Marketplace presentation Has correct title](https://github.com/camel-tooling/camel-dap-client-vscode/assets/46084942/711d62bc-c4b0-40e7-9974-450f3b02ea24)

```
  1) Install test
       Marketplace presentation
         Has correct title:
     StaleElementReferenceError: stale element reference: element is not attached to the page document
  (Session info: chrome=102.0.5005.196)
      at Object.throwDecodedError (node_modules/selenium-webdriver/lib/error.js:524:15)
      at parseHttpResponse (node_modules/selenium-webdriver/lib/http.js:601:13)
      at Executor.execute (node_modules/selenium-webdriver/lib/http.js:529:28)
      at runMicrotasks (<anonymous>)
      at processTicksAndRejections (node:internal/process/task_queues:96:5)
      at async Driver.execute (node_modules/selenium-webdriver/lib/webdriver.js:745:17)
```