### PR TITLE
FUSETOOLS2-1743 Add JBang lense debug test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
 				"jsonc-parser": "^3.2.0"
 			},
 			"devDependencies": {
-				"@theia-extension-tester/repeat": "^0.1.2",
 				"@types/chai": "^4.3.5",
 				"@types/glob": "^8.1.0",
 				"@types/mocha": "^10.0.1",
@@ -367,21 +366,6 @@
 			"engines": {
 				"node": ">=14.16"
 			}
-		},
-		"node_modules/@theia-extension-tester/repeat": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/@theia-extension-tester/repeat/-/repeat-0.1.2.tgz",
-			"integrity": "sha512-nlJlvsr1pJrl9qj65SsQcq2SrgZGw+7aWGL662scvweuvIbaMPiAkU3vw3fJwWVgkVHG3QJfu1KFomcSjYS3zA==",
-			"dev": true,
-			"dependencies": {
-				"@theia-extension-tester/timeout-promise": "^0.1.2"
-			}
-		},
-		"node_modules/@theia-extension-tester/timeout-promise": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/@theia-extension-tester/timeout-promise/-/timeout-promise-0.1.2.tgz",
-			"integrity": "sha512-k3nwaXfjAFBkgqymQDLzcfBRZ6RzNPrSxKOS5bOv0VOf4hEc5ql7z1Pq5Z/iM183ZX9/B8vtMT7P79xe9cBSww==",
-			"dev": true
 		},
 		"node_modules/@tootallnate/once": {
 			"version": "1.1.2",
@@ -5564,21 +5548,6 @@
 			"requires": {
 				"defer-to-connect": "^2.0.1"
 			}
-		},
-		"@theia-extension-tester/repeat": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/@theia-extension-tester/repeat/-/repeat-0.1.2.tgz",
-			"integrity": "sha512-nlJlvsr1pJrl9qj65SsQcq2SrgZGw+7aWGL662scvweuvIbaMPiAkU3vw3fJwWVgkVHG3QJfu1KFomcSjYS3zA==",
-			"dev": true,
-			"requires": {
-				"@theia-extension-tester/timeout-promise": "^0.1.2"
-			}
-		},
-		"@theia-extension-tester/timeout-promise": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/@theia-extension-tester/timeout-promise/-/timeout-promise-0.1.2.tgz",
-			"integrity": "sha512-k3nwaXfjAFBkgqymQDLzcfBRZ6RzNPrSxKOS5bOv0VOf4hEc5ql7z1Pq5Z/iM183ZX9/B8vtMT7P79xe9cBSww==",
-			"dev": true
 		},
 		"@tootallnate/once": {
 			"version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -221,7 +221,6 @@
 		"ui-test": "node --unhandled-rejections=warn-with-error-code out/ui-test/uitest_runner.js"
 	},
 	"devDependencies": {
-		"@theia-extension-tester/repeat": "^0.1.2",
 		"@types/chai": "^4.3.5",
 		"@types/glob": "^8.1.0",
 		"@types/mocha": "^10.0.1",

--- a/src/ui-test/tests/01_install.test.ts
+++ b/src/ui-test/tests/01_install.test.ts
@@ -1,7 +1,6 @@
 import { expect } from 'chai';
 import * as fs from 'fs';
-import * as path from 'path';
-import { repeat, TimeoutError } from '@theia-extension-tester/repeat';
+import * as path  from 'path';
 import {
     after,
     before,
@@ -12,7 +11,9 @@ import {
     ExtensionsViewItem,
     ExtensionsViewSection,
     InputBox,
+    repeat,
     SideBarView,
+    TimeoutError,
     ViewControl,
     VSBrowser,
     Workbench

--- a/src/ui-test/tests/codelens.test.ts
+++ b/src/ui-test/tests/codelens.test.ts
@@ -1,0 +1,60 @@
+import * as path from 'path';
+import * as variables from '../variables';
+import {
+    ActivityBar,
+    after,
+    before,
+    EditorView,
+    repeat,
+    SideBarView,
+    VSBrowser,
+    WebDriver
+} from 'vscode-uitests-tooling';
+import {
+    disconnectDebugger,
+    findCodelens,
+    killTerminal,
+    waitUntilTerminalHasText
+} from '../utils';
+
+describe('JBang commands execution through command codelens', function () {
+    this.timeout(240000);
+
+    let driver: WebDriver;
+
+    before(async function () {
+        driver = VSBrowser.instance.driver;
+    });
+
+    after(async function () {
+        await new EditorView().closeAllEditors();
+    });
+
+    beforeEach(async function () {
+        await VSBrowser.instance.openResources(path.resolve('src', 'ui-test', 'resources'));
+
+        await (await new ActivityBar().getViewControl('Explorer')).openView();
+
+        const section = await new SideBarView().getContent().getSection('resources');
+        await section.openItem(variables.CAMEL_ROUTE_YAML_WITH_SPACE);
+
+        const editorView = new EditorView();
+        await repeat(async function () {
+            return (await editorView.getOpenEditorTitles()).find(title => title === variables.CAMEL_ROUTE_YAML_WITH_SPACE);
+        }, {
+            timeout: 5000,
+            message: `The test file ${variables.CAMEL_ROUTE_YAML_WITH_SPACE} was not opened`
+        });
+    });
+
+    afterEach(async function () {
+        await killTerminal();
+    });
+
+    it(`Execute command 'apache.camel.debug.jbang' with codelens '${variables.CAMEL_DEBUG_CODELENS}'`, async function () {
+        await (await findCodelens(variables.CAMEL_DEBUG_CODELENS)).click();
+        await waitUntilTerminalHasText(driver, variables.TEST_ARRAY_RUN_DEBUG, 4000, 120000);
+        await disconnectDebugger(driver);
+        await (await new ActivityBar().getViewControl('Run and Debug')).closeView();
+    });
+});

--- a/src/ui-test/uitest_runner.ts
+++ b/src/ui-test/uitest_runner.ts
@@ -18,17 +18,18 @@
 
 import * as path from 'path';
 import * as fs from 'fs';
+import * as variables from './variables';
 import { ExTester } from 'vscode-extension-tester';
 import { ReleaseQuality } from 'vscode-extension-tester/out/util/codeUtil';
 
-export const storageFolder = 'test-resources';
+export const storageFolder = variables.TEST_RESOURCES_DIR;
 const releaseType: ReleaseQuality = process.env.CODE_TYPE === 'insider' ? ReleaseQuality.Insider : ReleaseQuality.Stable;
 export const projectPath = path.resolve(__dirname, '..', '..');
-const extensionFolder = path.join(projectPath, '.test-extensions');
+const extensionFolder = variables.EXTENSION_DIR;
 
 async function main(): Promise<void> {
 	const tester = new ExTester(storageFolder, releaseType, extensionFolder);
-	await tester.setupAndRunTests('out/ui-test/tests/*.test.js',
+	await tester.setupAndRunTests('out/ui-test/tests/**/*.test.js',
 		process.env.CODE_VERSION,
 		{
 			'installDependencies': true

--- a/src/ui-test/utils.ts
+++ b/src/ui-test/utils.ts
@@ -2,6 +2,7 @@ import {
     ActivityBar,
     BottomBarPanel,
     BreakpointSectionItem,
+    CodeLens,
     ContextMenu,
     ContextMenuItem,
     DebugToolbar,
@@ -14,6 +15,9 @@ import {
     ViewItem,
     WebDriver,
     Workbench,
+    error,
+    errors,
+    repeat,
     until
 } from 'vscode-uitests-tooling';
 
@@ -234,4 +238,20 @@ export async function getBreakpoint(driver: WebDriver, line: number): Promise<Br
             return undefined;
         }
     }, 5000, undefined, 500);
+}
+
+/**
+ * Finds a specific CodeLens with the given title.
+ * @param title The title of the CodeLens to find.
+ * @returns A Promise that resolves to the found CodeLens.
+ */
+export async function findCodelens(title: string): Promise<CodeLens> {
+    return await repeat(async () => {
+        const editor = new TextEditor();
+        return await editor.getCodeLens(title);
+    }, {
+        timeout: 5000,
+        ignoreErrors: [...errors.INTERACTIVITY_ERRORS, error.TimeoutError],
+        message: `could not find codelens: ${title}`
+    });
 }

--- a/src/ui-test/variables.ts
+++ b/src/ui-test/variables.ts
@@ -1,0 +1,32 @@
+import * as path from 'path';
+
+export const TEST_RESOURCES_DIR = path.resolve('.', 'test-resources');
+export const EXTENSION_DIR = path.join(TEST_RESOURCES_DIR, 'test-extensions');
+export const WORKBENCH_DIR = path.join(TEST_RESOURCES_DIR, 'ui-workbench');
+export const RESOURCES_DIR = path.resolve('.', 'src', 'ui-test', 'resources');
+
+export const DEFAULT_HEADER = 'YamlHeader';
+export const DEFAULT_PROPERTY = 'yaml-dsl';
+export const DEFAULT_BODY = 'Hello Camel from';
+export const DEFAULT_MESSAGE = `${DEFAULT_HEADER}: ${DEFAULT_BODY} ${DEFAULT_PROPERTY}`;
+
+export const TEST_HEADER = 'TestHeader';
+export const TEST_PROPERTY = 'test-dsl';
+export const TEST_BODY = 'Hello World from';
+export const TEST_MESSAGE = `${TEST_HEADER}: ${TEST_BODY} ${TEST_PROPERTY}`;
+
+export const TEST_ARRAY_RUN = [
+    'Routes startup',
+    DEFAULT_MESSAGE
+];
+export const TEST_ARRAY_RUN_DEBUG = TEST_ARRAY_RUN.concat([
+    'Enabling Camel debugger',
+    'debugger has been attached'
+]);
+
+export const CAMEL_RUN_DEBUG_ACTION_LABEL = 'Run Camel Application with JBang and Debug';
+export const CAMEL_RUN_ACTION_LABEL = 'Run Camel Application with JBang';
+export const CAMEL_ROUTE_YAML_WITH_SPACE = 'demo route.camel.yaml';
+export const CAMEL_ROUTE_YAML_WITH_SPACE_COPY = 'demo route copy.camel.yaml';
+export const CAMEL_DEBUG_CODELENS = 'Camel Debug with JBang';
+export const CAMEL_RUN_CODELENS = 'Camel Run with JBang';


### PR DESCRIPTION
Add test to check whether it is possible to debug yaml file using debug codelense. It verifies that debugger is launched and the program pauses at the selected breakpoints.

Please note, as part of this PR I have experimented with variables structure, because I believe single utils.ts is not optimal as long term solution. Also, I have marked a few candidates to vscode-uitestest-tooling and I would value your feedback regarding those proposed functions.