### PR TITLE
FUSETOOLS2-2111: Add Set Header test

### DIFF
--- a/src/ui-test/resources/demo route.camel.yaml
+++ b/src/ui-test/resources/demo route.camel.yaml
@@ -8,4 +8,8 @@
     steps:
       - setBody:
           constant: "Hello Camel from yaml"
-      - log: "${body}"
+      - setHeader:
+          name: "header"
+          constant: "YamlHeader"
+      - log: "${header.header}: ${body}"
+

--- a/src/ui-test/tests/camel.settings.test.ts
+++ b/src/ui-test/tests/camel.settings.test.ts
@@ -17,7 +17,7 @@
 import { expect } from 'chai';
 import { Workbench, VSBrowser, EditorView, WebDriver, after, before, ActivityBar, SideBarView, BottomBarPanel } from 'vscode-uitests-tooling';
 import * as path from 'path';
-import { CAMEL_ROUTE_YAML_WITH_SPACE, CAMEL_RUN_ACTION_LABEL, HELLO_CAMEL_MESSAGE, TEST_ARRAY_RUN, activateTerminalView, executeCommand, killTerminal, waitUntilTerminalHasText } from '../utils';
+import { CAMEL_ROUTE_YAML_WITH_SPACE, CAMEL_RUN_ACTION_LABEL, TEST_ARRAY_RUN, DEFAULT_MESSAGE, activateTerminalView, executeCommand, killTerminal, waitUntilTerminalHasText } from '../utils';
 import * as fs from 'node:fs';
 import { storageFolder } from '../uitest_runner';
 
@@ -69,7 +69,7 @@ describe('Camel User Settings', function () {
 
             await waitUntilTerminalHasText(driver, TEST_ARRAY_RUN);
             expect(await (await activateTerminalView()).getText()).to.contain(`Apache Camel ${customCamelVersion} (demo route) started`);
-            expect(await (await activateTerminalView()).getText()).to.contain(HELLO_CAMEL_MESSAGE);
+            expect(await (await activateTerminalView()).getText()).to.contain(DEFAULT_MESSAGE);
         });
 
     });

--- a/src/ui-test/tests/command.palette.test.ts
+++ b/src/ui-test/tests/command.palette.test.ts
@@ -18,7 +18,7 @@ import {
     disconnectDebugger,
     killTerminal,
     DEBUGGER_ATTACHED_MESSAGE,
-    HELLO_CAMEL_MESSAGE,
+    DEFAULT_MESSAGE,
     activateTerminalView,
     CAMEL_ROUTE_YAML_WITH_SPACE,
 } from '../utils';
@@ -58,7 +58,7 @@ describe('JBang commands execution through command palette', function () {
     it(`Execute command '${CAMEL_RUN_ACTION_LABEL}' in command palette`, async function () {
         await executeCommand(CAMEL_RUN_ACTION_LABEL);
         await waitUntilTerminalHasText(driver, TEST_ARRAY_RUN);
-        expect(await (await activateTerminalView()).getText()).to.contain(HELLO_CAMEL_MESSAGE);
+        expect(await (await activateTerminalView()).getText()).to.contain(DEFAULT_MESSAGE);
     });
 
     it(`Execute command '${CAMEL_RUN_DEBUG_ACTION_LABEL}' in command palette`, async function () {
@@ -66,7 +66,7 @@ describe('JBang commands execution through command palette', function () {
         await waitUntilTerminalHasText(driver, TEST_ARRAY_RUN_DEBUG);
         const terminalLog = await (await activateTerminalView()).getText();
         expect(terminalLog).to.contain(DEBUGGER_ATTACHED_MESSAGE);
-        expect(terminalLog).to.contain(HELLO_CAMEL_MESSAGE);
+        expect(terminalLog).to.contain(DEFAULT_MESSAGE);
         await disconnectDebugger(driver);
         await (await new ActivityBar().getViewControl('Run and Debug')).closeView();
     });

--- a/src/ui-test/tests/context.menu.test.ts
+++ b/src/ui-test/tests/context.menu.test.ts
@@ -14,7 +14,7 @@ import {
     CAMEL_RUN_ACTION_LABEL,
     CAMEL_RUN_DEBUG_ACTION_LABEL,
     DEBUGGER_ATTACHED_MESSAGE,
-    HELLO_CAMEL_MESSAGE,
+    DEFAULT_MESSAGE,
     TEST_ARRAY_RUN,
     TEST_ARRAY_RUN_DEBUG,
     activateTerminalView,
@@ -69,7 +69,7 @@ import {
     it(`Execute command '${CAMEL_RUN_ACTION_LABEL}' in context menu`, async function () {
         await selectContextMenuItem(CAMEL_RUN_ACTION_LABEL, await openContextMenu(CAMEL_ROUTE_YAML_WITH_SPACE));
         await waitUntilTerminalHasText(driver, TEST_ARRAY_RUN);
-        expect(await (await activateTerminalView()).getText()).to.contain(HELLO_CAMEL_MESSAGE);
+        expect(await (await activateTerminalView()).getText()).to.contain(DEFAULT_MESSAGE);
         await killTerminal();
     });
 
@@ -78,7 +78,7 @@ import {
         await waitUntilTerminalHasText(driver, TEST_ARRAY_RUN_DEBUG);
         const terminalLog = await (await activateTerminalView()).getText();
         expect(terminalLog).to.contain(DEBUGGER_ATTACHED_MESSAGE);
-        expect(terminalLog).to.contain(HELLO_CAMEL_MESSAGE);
+        expect(terminalLog).to.contain(DEFAULT_MESSAGE);
         await (await new ActivityBar().getViewControl('Run and Debug')).closeView();
         await disconnectDebugger(driver);
         await killTerminal();

--- a/src/ui-test/tests/editor.actions.test.ts
+++ b/src/ui-test/tests/editor.actions.test.ts
@@ -19,9 +19,9 @@ import {
     activateTerminalView,
     killTerminal,
     disconnectDebugger,
-    HELLO_CAMEL_MESSAGE,
     TEST_ARRAY_RUN,
-    DEBUGGER_ATTACHED_MESSAGE
+    DEBUGGER_ATTACHED_MESSAGE,
+    DEFAULT_MESSAGE
 } from '../utils';
 
 describe('Camel file editor test', function () {
@@ -69,7 +69,7 @@ describe('Camel file editor test', function () {
             await run.click();
 
             await waitUntilTerminalHasText(driver, TEST_ARRAY_RUN);
-            expect(await (await activateTerminalView()).getText()).to.contain(HELLO_CAMEL_MESSAGE);
+            expect(await (await activateTerminalView()).getText()).to.contain(DEFAULT_MESSAGE);
 
             await killTerminal();
         });
@@ -81,7 +81,7 @@ describe('Camel file editor test', function () {
             await waitUntilTerminalHasText(driver, TEST_ARRAY_RUN);
             const terminalLog = await (await activateTerminalView()).getText();
             expect(terminalLog).to.contain(DEBUGGER_ATTACHED_MESSAGE);
-            expect(terminalLog).to.contain(HELLO_CAMEL_MESSAGE);
+            expect(terminalLog).to.contain(DEFAULT_MESSAGE);
 
             await (await new ActivityBar().getViewControl('Run and Debug')).closeView();
             await disconnectDebugger(driver);

--- a/src/ui-test/tests/reload.test.ts
+++ b/src/ui-test/tests/reload.test.ts
@@ -16,12 +16,15 @@ import {
     TEST_ARRAY_RUN,
     executeCommand,
     killTerminal,
-    HELLO_CAMEL_MESSAGE,
+    TEST_MESSAGE,
     activateTerminalView,
     CAMEL_ROUTE_YAML_WITH_SPACE,
-    HELLO_WORLD_MESSAGE,
     CAMEL_ROUTE_YAML_WITH_SPACE_COPY,
     replaceTextInCodeEditor,
+    DEFAULT_BODY,
+    TEST_BODY,
+    DEFAULT_HEADER,
+    TEST_HEADER,
 } from '../utils';
 import { expect } from 'chai';
 
@@ -75,9 +78,10 @@ describe('Jbang commands with automatic reload', function () {
         await executeCommand(CAMEL_RUN_ACTION_LABEL);
         await waitUntilTerminalHasText(driver, TEST_ARRAY_RUN);
 
-        await driver.wait(async () => { return await replaceTextInCodeEditor(HELLO_CAMEL_MESSAGE, HELLO_WORLD_MESSAGE); }, 60000);
-        await waitUntilTerminalHasText(driver, [HELLO_WORLD_MESSAGE]);
+        await driver.wait(async () => { return await replaceTextInCodeEditor(DEFAULT_BODY, TEST_BODY); }, 60000);
+        await driver.wait(async () => { return await replaceTextInCodeEditor(DEFAULT_HEADER, TEST_HEADER); }, 60000);
 
-        expect(await (await activateTerminalView()).getText()).to.contain(HELLO_WORLD_MESSAGE);
+        await waitUntilTerminalHasText(driver, [TEST_MESSAGE]);
+        expect(await (await activateTerminalView()).getText()).to.contain(TEST_MESSAGE);
     });
 });

--- a/src/ui-test/utils.ts
+++ b/src/ui-test/utils.ts
@@ -13,12 +13,18 @@ import {
     until
 } from 'vscode-uitests-tooling';
 
-export const HELLO_CAMEL_MESSAGE = 'Hello Camel from yaml';
-export const HELLO_WORLD_MESSAGE = 'Hello World from yaml';
+export const DEFAULT_BODY = 'Hello Camel from yaml';
+export const DEFAULT_HEADER = 'YamlHeader';
+export const DEFAULT_MESSAGE = `${DEFAULT_HEADER}: ${DEFAULT_BODY}`;
+
+export const TEST_BODY = 'Hello World from yaml';
+export const TEST_HEADER = 'TestHeader';
+export const TEST_MESSAGE = `${TEST_HEADER}: ${TEST_BODY}`;
+
 export const DEBUGGER_ATTACHED_MESSAGE = 'debugger has been attached';
 export const TEST_ARRAY_RUN = [
     'Routes startup',
-    HELLO_CAMEL_MESSAGE
+    DEFAULT_MESSAGE
 ];
 export const TEST_ARRAY_RUN_DEBUG = TEST_ARRAY_RUN.concat([
     'Enabling Camel debugger',


### PR DESCRIPTION
Hi, added the test according to the issue https://issues.redhat.com/browse/FUSETOOLS2-2111

  Camel Debugger tests
    ✔ Toogle breakpoint on log line (14) (17249ms)
    ✔ Update Body value with Camel debugger (15595ms)
    ✔ Update Header value with Camel debugger (15216ms)
    ✔ Click on Continue button, and check updated message (14352ms)
    ✔ Untoogle breakpoint on log line (14) (511ms)
    
Extra:
- Changed template file (header added)
- Changed common variables to reflect file changes
- Added test with continue button click to see logout of next iteration in the debugger
