### PR TITLE
FUSETOOLS2-2154: Add Set Exchange property test

### DIFF
--- a/.github/workflows/insider.yaml
+++ b/.github/workflows/insider.yaml
@@ -17,6 +17,7 @@ jobs:
         version: [latest] # [x.x.x | latest | max]
         type: [insider] # [stable | insider]
       fail-fast: false
+    timeout-minutes: 20
 
     env:
       CODE_VERSION: ${{ matrix.version }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,6 +19,7 @@ jobs:
         version: ["1.76.2", max] # ["x.x.x" | latest | max]
         type: [stable] # [stable | insider]
       fail-fast: false
+    timeout-minutes: 20
 
     env:
       CODE_VERSION: ${{ matrix.version }}

--- a/src/ui-test/resources/demo route.camel.yaml
+++ b/src/ui-test/resources/demo route.camel.yaml
@@ -4,12 +4,14 @@
 - from:
     uri: "timer:yaml"
     parameters:
-      period: "1000"
+      period: "2000"
     steps:
-      - setBody:
-          constant: "Hello Camel from yaml"
       - setHeader:
           name: "header"
           constant: "YamlHeader"
-      - log: "${header.header}: ${body}"
-
+      - setProperty:
+          name: "from"
+          constant: "yaml-dsl"
+      - setBody:
+          constant: "Hello Camel from"
+      - log: "${header.header}: ${body} ${exchangeProperty.from}"

--- a/src/ui-test/tests/camel.settings.test.ts
+++ b/src/ui-test/tests/camel.settings.test.ts
@@ -14,10 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { expect } from 'chai';
 import { Workbench, VSBrowser, EditorView, WebDriver, after, before, ActivityBar, SideBarView, BottomBarPanel } from 'vscode-uitests-tooling';
 import * as path from 'path';
-import { CAMEL_ROUTE_YAML_WITH_SPACE, CAMEL_RUN_ACTION_LABEL, TEST_ARRAY_RUN, DEFAULT_MESSAGE, activateTerminalView, executeCommand, killTerminal, waitUntilTerminalHasText } from '../utils';
+import { CAMEL_ROUTE_YAML_WITH_SPACE, CAMEL_RUN_ACTION_LABEL, TEST_ARRAY_RUN, executeCommand, killTerminal, waitUntilTerminalHasText } from '../utils';
 import * as fs from 'node:fs';
 import { storageFolder } from '../uitest_runner';
 
@@ -64,12 +63,7 @@ describe('Camel User Settings', function () {
             await setCamelVersion(customCamelVersion);
             await executeCommand(CAMEL_RUN_ACTION_LABEL);
 
-            await waitUntilTerminalHasText(driver, [`--camel-version=${customCamelVersion}`]);
-            expect(await (await activateTerminalView()).getText()).to.contain(`--camel-version=${customCamelVersion}`);
-
-            await waitUntilTerminalHasText(driver, TEST_ARRAY_RUN);
-            expect(await (await activateTerminalView()).getText()).to.contain(`Apache Camel ${customCamelVersion} (demo route) started`);
-            expect(await (await activateTerminalView()).getText()).to.contain(DEFAULT_MESSAGE);
+            await waitUntilTerminalHasText(driver, [`--camel-version=${customCamelVersion}`, ...TEST_ARRAY_RUN], 15000, 180000);
         });
 
     });
@@ -90,7 +84,6 @@ describe('Camel User Settings', function () {
             await executeCommand(CAMEL_RUN_ACTION_LABEL);
 
             await waitUntilTerminalHasText(driver, [`-Dcamel.jbang.version=${defaultJBangVersion}`]);
-            expect(await (await activateTerminalView()).getText()).to.contain(`-Dcamel.jbang.version=${defaultJBangVersion}`);
         });
 
         it(`Should use user defined JBang version '${customJBangVersion}'`, async function () {
@@ -99,7 +92,6 @@ describe('Camel User Settings', function () {
             await executeCommand(CAMEL_RUN_ACTION_LABEL);
 
             await waitUntilTerminalHasText(driver, [`-Dcamel.jbang.version=${customJBangVersion}`]);
-            expect(await (await activateTerminalView()).getText()).to.contain(`-Dcamel.jbang.version=${customJBangVersion}`);
         });
 
     });

--- a/src/ui-test/tests/command.palette.test.ts
+++ b/src/ui-test/tests/command.palette.test.ts
@@ -17,12 +17,8 @@ import {
     executeCommand,
     disconnectDebugger,
     killTerminal,
-    DEBUGGER_ATTACHED_MESSAGE,
-    DEFAULT_MESSAGE,
-    activateTerminalView,
     CAMEL_ROUTE_YAML_WITH_SPACE,
 } from '../utils';
-import { expect } from 'chai';
 
 describe('JBang commands execution through command palette', function () {
     this.timeout(240000);
@@ -58,15 +54,11 @@ describe('JBang commands execution through command palette', function () {
     it(`Execute command '${CAMEL_RUN_ACTION_LABEL}' in command palette`, async function () {
         await executeCommand(CAMEL_RUN_ACTION_LABEL);
         await waitUntilTerminalHasText(driver, TEST_ARRAY_RUN);
-        expect(await (await activateTerminalView()).getText()).to.contain(DEFAULT_MESSAGE);
     });
 
     it(`Execute command '${CAMEL_RUN_DEBUG_ACTION_LABEL}' in command palette`, async function () {
         await executeCommand(CAMEL_RUN_DEBUG_ACTION_LABEL);
         await waitUntilTerminalHasText(driver, TEST_ARRAY_RUN_DEBUG);
-        const terminalLog = await (await activateTerminalView()).getText();
-        expect(terminalLog).to.contain(DEBUGGER_ATTACHED_MESSAGE);
-        expect(terminalLog).to.contain(DEFAULT_MESSAGE);
         await disconnectDebugger(driver);
         await (await new ActivityBar().getViewControl('Run and Debug')).closeView();
     });

--- a/src/ui-test/tests/context.menu.test.ts
+++ b/src/ui-test/tests/context.menu.test.ts
@@ -13,11 +13,8 @@ import {
     CAMEL_ROUTE_YAML_WITH_SPACE,
     CAMEL_RUN_ACTION_LABEL,
     CAMEL_RUN_DEBUG_ACTION_LABEL,
-    DEBUGGER_ATTACHED_MESSAGE,
-    DEFAULT_MESSAGE,
     TEST_ARRAY_RUN,
     TEST_ARRAY_RUN_DEBUG,
-    activateTerminalView,
     disconnectDebugger,
     killTerminal,
     openContextMenu,
@@ -69,16 +66,12 @@ import {
     it(`Execute command '${CAMEL_RUN_ACTION_LABEL}' in context menu`, async function () {
         await selectContextMenuItem(CAMEL_RUN_ACTION_LABEL, await openContextMenu(CAMEL_ROUTE_YAML_WITH_SPACE));
         await waitUntilTerminalHasText(driver, TEST_ARRAY_RUN);
-        expect(await (await activateTerminalView()).getText()).to.contain(DEFAULT_MESSAGE);
         await killTerminal();
     });
 
     it(`Execute command '${CAMEL_RUN_DEBUG_ACTION_LABEL}' in context menu`, async function () {
         await selectContextMenuItem(CAMEL_RUN_DEBUG_ACTION_LABEL, await openContextMenu(CAMEL_ROUTE_YAML_WITH_SPACE));
         await waitUntilTerminalHasText(driver, TEST_ARRAY_RUN_DEBUG);
-        const terminalLog = await (await activateTerminalView()).getText();
-        expect(terminalLog).to.contain(DEBUGGER_ATTACHED_MESSAGE);
-        expect(terminalLog).to.contain(DEFAULT_MESSAGE);
         await (await new ActivityBar().getViewControl('Run and Debug')).closeView();
         await disconnectDebugger(driver);
         await killTerminal();

--- a/src/ui-test/tests/debugger.test.ts
+++ b/src/ui-test/tests/debugger.test.ts
@@ -19,17 +19,22 @@ import {
     TEST_HEADER,
     TEST_MESSAGE,
     TEST_ARRAY_RUN_DEBUG,
-    activateTerminalView,
     disconnectDebugger,
     executeCommand,
     killTerminal,
-    waitUntilTerminalHasText
+    waitUntilTerminalHasText,
+    TEST_PROPERTY,
+    DEFAULT_PROPERTY,
+    clearTerminal
 } from '../utils';
 
 describe('Camel Debugger tests', function () {
     this.timeout(300000);
 
     let driver: WebDriver;
+
+    let skip: boolean = true;
+    let breakpointToggled: boolean = false;
 
     before(async function () {
         driver = VSBrowser.instance.driver;
@@ -45,6 +50,10 @@ describe('Camel Debugger tests', function () {
         await driver.wait(async function () {
             return (await editorView.getOpenEditorTitles()).find(title => title === CAMEL_ROUTE_YAML_WITH_SPACE);
         }, 5000);
+
+        await executeCommand(CAMEL_RUN_DEBUG_ACTION_LABEL);
+        await (await new ActivityBar().getViewControl('Run')).openView();
+        await waitUntilTerminalHasText(driver, TEST_ARRAY_RUN_DEBUG);
     });
 
     after(async function () {
@@ -54,15 +63,19 @@ describe('Camel Debugger tests', function () {
         await new EditorView().closeAllEditors();
     });
 
-    it('Toogle breakpoint on log line (14)', async function () {
-        await executeCommand(CAMEL_RUN_DEBUG_ACTION_LABEL);
-        await waitUntilTerminalHasText(driver, TEST_ARRAY_RUN_DEBUG);
+    it('Toggle breakpoint on log line (17)', async function () {
         await driver.wait(async function () {
-            return await new TextEditor().toggleBreakpoint(14);
+            return await new TextEditor().toggleBreakpoint(17);
         }, 5000);
+        breakpointToggled = true;
+        skip = false;
     });
 
     it('Update Body value with Camel debugger', async function () {
+        if (skip) {
+            this.test?.skip();
+        }
+        skip = true;
         // WORKAROUND: https://github.com/redhat-developer/vscode-extension-tester/issues/402
         const debugView = (await (await new ActivityBar().getViewControl('Run')).openView()) as DebugView;
         await driver.wait(async function () {
@@ -81,15 +94,23 @@ describe('Camel Debugger tests', function () {
             } catch (e) {
                 // Extra click to avoid the error: "Element is not clickable at point (x, y)"
                 // Issue is similar to https://issues.redhat.com/browse/FUSETOOLS2-2100
-                await driver.actions().click().perform();
+                if (e instanceof Error && e.name === 'ElementClickInterceptedError') {
+                    await driver.actions().click().perform();
+                }
+                return false;
             }
         }, 240000, undefined, 500);
 
         await waitUntilTerminalHasText(driver, [TEST_BODY]);
-        expect(await (await activateTerminalView()).getText()).to.contain(TEST_BODY);
+        await clearTerminal();
+        skip = false;
     });
 
     it('Update Header value with Camel debugger', async function () {
+        if (skip) {
+            this.test?.skip();
+        }
+        skip = true;
         // WORKAROUND: https://github.com/redhat-developer/vscode-extension-tester/issues/402
         const debugView = (await (await new ActivityBar().getViewControl('Run')).openView()) as DebugView;
         await driver.wait(async function () {
@@ -108,24 +129,84 @@ describe('Camel Debugger tests', function () {
             } catch (e) {
                 // Extra click to avoid the error: "Element is not clickable at point (x, y)"
                 // Issue is similar to https://issues.redhat.com/browse/FUSETOOLS2-2100
-                await driver.actions().click().perform();
+                if (e instanceof Error && e.name === 'ElementClickInterceptedError') {
+                    await driver.actions().click().perform();
+                }
+                return false;
             }
         }, 240000, undefined, 500);
 
         await waitUntilTerminalHasText(driver, [TEST_HEADER]);
-        expect(await (await activateTerminalView()).getText()).to.contain(TEST_HEADER);
+        await clearTerminal();
+        skip = false;
+    });
+
+    it('Update Exchange property value with Camel debugger', async function () {
+        if (skip) {
+            this.test?.skip();
+        }
+        skip = true;
+        // WORKAROUND: https://github.com/redhat-developer/vscode-extension-tester/issues/402
+        // Exchange -> Properties -> from:fromL yaml)
+        const debugView = (await (await new ActivityBar().getViewControl('Run')).openView()) as DebugView;
+        await driver.wait(async function () {
+            try {
+                let variables = await debugView.getContent().getSection('Variables');
+                await variables.openItem('Exchange');
+                const messages = await variables.openItem('Properties');
+                for await (let message of messages) {
+                    if (await message.getAttribute('aria-label') === `from, value ${DEFAULT_PROPERTY}`) {
+                        await driver.actions().doubleClick(message).perform();
+                        await driver.actions().clear();
+                        await driver.actions().sendKeys(TEST_PROPERTY).perform();
+                        return true;
+                    }
+                }
+                return false;
+            } catch (e) {
+                // Extra click to avoid the error: "Element is not clickable at point (x, y)"
+                // Issue is similar to https://issues.redhat.com/browse/FUSETOOLS2-2100
+                if (e instanceof Error && e.name === 'ElementClickInterceptedError') {
+                    await driver.actions().click().perform();
+                }
+                return false;
+            }
+        }, 240000, undefined, 500);
+
+        // Lack of camel.impl.debugger.BacklogDebugger logs on Exchange property changes
+        // Not possible to verify that value was changed in terminal
+        // Verify that value was changed in Run&Debug variables view
+        let foundMessageWithTestProperty = false;
+        let variables = await debugView.getContent().getSection('Variables');
+        const messages = await variables.openItem('Properties');
+        for await (let message of messages) {
+            if (await message.getAttribute('aria-label') === `from, value ${TEST_PROPERTY}`) {
+                foundMessageWithTestProperty = true;
+            }
+        }
+
+        expect(foundMessageWithTestProperty).to.be.true;
+        await clearTerminal();
+        skip = false;
     });
 
     it('Click on Continue button, and check updated message', async function () {
+        if (skip) {
+            this.test?.skip();
+        }
+        skip = true;
         const debugBar = await DebugToolbar.create();
         await debugBar.continue();
         await waitUntilTerminalHasText(driver, [TEST_MESSAGE]);
-        expect(await (await activateTerminalView()).getText()).to.contain(TEST_MESSAGE);
+        skip = false;
     });
 
-    it('Untoogle breakpoint on log line (14)', async function () {
+    it('Untoggle breakpoint on log line (17)', async function () {
+        if (!breakpointToggled) {
+            this.test?.skip();
+        }
         await driver.wait(async function () {
-            return !await new TextEditor().toggleBreakpoint(14);
+            return !await new TextEditor().toggleBreakpoint(17);
         }, 5000);
     });
 

--- a/src/ui-test/tests/editor.actions.test.ts
+++ b/src/ui-test/tests/editor.actions.test.ts
@@ -16,12 +16,9 @@ import {
     CAMEL_RUN_ACTION_LABEL,
     CAMEL_RUN_DEBUG_ACTION_LABEL,
     waitUntilTerminalHasText,
-    activateTerminalView,
     killTerminal,
     disconnectDebugger,
-    TEST_ARRAY_RUN,
-    DEBUGGER_ATTACHED_MESSAGE,
-    DEFAULT_MESSAGE
+    TEST_ARRAY_RUN
 } from '../utils';
 
 describe('Camel file editor test', function () {
@@ -69,7 +66,6 @@ describe('Camel file editor test', function () {
             await run.click();
 
             await waitUntilTerminalHasText(driver, TEST_ARRAY_RUN);
-            expect(await (await activateTerminalView()).getText()).to.contain(DEFAULT_MESSAGE);
 
             await killTerminal();
         });
@@ -79,9 +75,6 @@ describe('Camel file editor test', function () {
             await run.click();
 
             await waitUntilTerminalHasText(driver, TEST_ARRAY_RUN);
-            const terminalLog = await (await activateTerminalView()).getText();
-            expect(terminalLog).to.contain(DEBUGGER_ATTACHED_MESSAGE);
-            expect(terminalLog).to.contain(DEFAULT_MESSAGE);
 
             await (await new ActivityBar().getViewControl('Run and Debug')).closeView();
             await disconnectDebugger(driver);

--- a/src/ui-test/utils.ts
+++ b/src/ui-test/utils.ts
@@ -13,13 +13,17 @@ import {
     until
 } from 'vscode-uitests-tooling';
 
-export const DEFAULT_BODY = 'Hello Camel from yaml';
 export const DEFAULT_HEADER = 'YamlHeader';
-export const DEFAULT_MESSAGE = `${DEFAULT_HEADER}: ${DEFAULT_BODY}`;
+export const DEFAULT_PROPERTY = 'yaml-dsl';
+export const DEFAULT_BODY = 'Hello Camel from';
 
-export const TEST_BODY = 'Hello World from yaml';
+export const DEFAULT_MESSAGE = `${DEFAULT_HEADER}: ${DEFAULT_BODY} ${DEFAULT_PROPERTY}`;
+
 export const TEST_HEADER = 'TestHeader';
-export const TEST_MESSAGE = `${TEST_HEADER}: ${TEST_BODY}`;
+export const TEST_PROPERTY = 'test-dsl';
+export const TEST_BODY = 'Hello World from';
+
+export const TEST_MESSAGE = `${TEST_HEADER}: ${TEST_BODY} ${TEST_PROPERTY}`;
 
 export const DEBUGGER_ATTACHED_MESSAGE = 'debugger has been attached';
 export const TEST_ARRAY_RUN = [
@@ -88,15 +92,16 @@ export async function selectContextMenuItem(command: string, menu: ContextMenu):
  * Checks if the terminal view has the specified texts in the given textArray.
  * @param driver The WebDriver instance to use.
  * @param textArray An array of strings representing the texts to search for in the terminal view.
- * @param interval (Optional) The interval in milliseconds to wait between checks. Default is 500ms.
+ * @param interval (Optional) The interval in milliseconds to wait between checks. Default is 2000ms.
+ * @param timeout (Optional) The timout in milliseconds. Default is 60000ms.
  * @returns A Promise that resolves to a boolean indicating whether the terminal view has the texts or not.
  */
-export async function waitUntilTerminalHasText(driver: WebDriver, textArray: string[], interval = 500): Promise<void> {
+export async function waitUntilTerminalHasText(driver: WebDriver, textArray: string[], interval = 2000, timeout = 60000): Promise<void> {
     await driver.wait(async function () {
         try {
             const terminal = await activateTerminalView();
             const terminalText = await terminal.getText();
-            for (const text of textArray) {
+            for await (const text of textArray) {
                 if (!(terminalText.includes(text))) {
                     return false;
                 };
@@ -105,7 +110,15 @@ export async function waitUntilTerminalHasText(driver: WebDriver, textArray: str
         } catch (err) {
             return false;
         }
-    }, 220000, undefined, interval);
+    }, timeout, undefined, interval);
+}
+
+/**
+ * Click on button to clear output in Terminal View
+ */
+export async function clearTerminal(): Promise<void> {
+    await activateTerminalView();
+    await new Workbench().executeCommand('terminal: clear');
 }
 
 /**


### PR DESCRIPTION
Hi, added the test according to the issue https://issues.redhat.com/browse/FUSETOOLS2-2154
   
Camel Debugger tests
    ✔ Toggle breakpoint on log line (17) (40658ms)
    ✔ Update Body value with Camel debugger (15664ms)
    ✔ Update Header value with Camel debugger (13338ms)
    ✔ Update Exchange property value with Camel debugger (3673ms)
    ✔ Click on Continue button, and check updated message (13461ms)
    ✔ Untoggle breakpoint on log line (17) (448ms)
 
 Extra:
- Changed template file (property added)
- Changed common variables to reflect file changes
- Separate reload test to three test for each changed element (body, header, property)

**Question/Possible Issue:**

I faced a lack of logs in `camel.impl.debugger.BacklogDebugger`

Example for Message/Body value:
2023-07-25 12:44:12.944  INFO 47051 --- [on(4)-127.0.0.1] camel.impl.debugger.BacklogDebugger : Breakpoint at node log1 is updating message body on exchangeId: EC2A49CFFCBC3AA-0000000000000000 with new body: TEST

But for Exchange properties for example newly added or CamelTimerPeriod, CamelTimerCounter
No logs in terminal in case of value changed

Variables (Changed `from`, `CamelTimerPeriod`, `Body` :
![Screenshot from 2023-07-25 12-47-19](https://github.com/camel-tooling/camel-dap-client-vscode/assets/46084942/3c93bc7e-e242-4f5d-9cbb-66461d18857d)

Logs:
![Screenshot from 2023-07-25 12-48-36](https://github.com/camel-tooling/camel-dap-client-vscode/assets/46084942/cbb8f082-d696-4a54-81ee-2f5d5242f939)

---

Extra  to avoid the error in root: 
   - Deleted redundant (always true) expect with getText() method
   - Added clean util to clean terminal
   - Increased log timeout and terminal check from 1s/0.5s to 2 seconds 
