### PR TITLE
Adjust timeouts based on test results

### DIFF
--- a/src/ui-test/tests/command.palette.test.ts
+++ b/src/ui-test/tests/command.palette.test.ts
@@ -58,7 +58,7 @@ describe('JBang commands execution through command palette', function () {
 
     it(`Execute command '${CAMEL_RUN_DEBUG_ACTION_LABEL}' in command palette`, async function () {
         await executeCommand(CAMEL_RUN_DEBUG_ACTION_LABEL);
-        await waitUntilTerminalHasText(driver, TEST_ARRAY_RUN_DEBUG);
+        await waitUntilTerminalHasText(driver, TEST_ARRAY_RUN_DEBUG, 4000, 120000);
         await disconnectDebugger(driver);
         await (await new ActivityBar().getViewControl('Run and Debug')).closeView();
     });

--- a/src/ui-test/tests/context.menu.test.ts
+++ b/src/ui-test/tests/context.menu.test.ts
@@ -71,7 +71,7 @@ import {
 
     it(`Execute command '${CAMEL_RUN_DEBUG_ACTION_LABEL}' in context menu`, async function () {
         await selectContextMenuItem(CAMEL_RUN_DEBUG_ACTION_LABEL, await openContextMenu(CAMEL_ROUTE_YAML_WITH_SPACE));
-        await waitUntilTerminalHasText(driver, TEST_ARRAY_RUN_DEBUG);
+        await waitUntilTerminalHasText(driver, TEST_ARRAY_RUN_DEBUG, 4000, 120000);
         await (await new ActivityBar().getViewControl('Run and Debug')).closeView();
         await disconnectDebugger(driver);
         await killTerminal();

--- a/src/ui-test/tests/debugger.test.ts
+++ b/src/ui-test/tests/debugger.test.ts
@@ -53,7 +53,7 @@ describe('Camel Debugger tests', function () {
 
         await executeCommand(CAMEL_RUN_DEBUG_ACTION_LABEL);
         await (await new ActivityBar().getViewControl('Run')).openView();
-        await waitUntilTerminalHasText(driver, TEST_ARRAY_RUN_DEBUG);
+        await waitUntilTerminalHasText(driver, TEST_ARRAY_RUN_DEBUG, 4000, 120000);
     });
 
     after(async function () {


### PR DESCRIPTION
Based on the latest test results (windows) need to adjust timeouts for debug actions from 60s to 120s with interval from 2s to 4s

Result: Increased stability of debug tests

Typical error:

  1) JBang commands execution through command palette
       Execute command 'Run Camel Application with JBang and Debug' in command palette:
     TimeoutError: Wait timed out after 65238ms
      at D:\a\camel-dap-client-vscode\camel-dap-client-vscode\node_modules\selenium-webdriver\lib\webdriver.js:929:17