### PR TITLE
Fix floating promises warings 

### DIFF
--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -45,4 +45,6 @@ async function main() {
 
 }
 
-main();
+main().catch((error) => {
+	console.error('Unhandled promise rejection in main: ', error);
+});

--- a/src/test/suite/completion.task.test.ts
+++ b/src/test/suite/completion.task.test.ts
@@ -3,20 +3,17 @@ import * as vscode from 'vscode';
 import { getDocUri } from './util';
 
 suite('Should do completion in tasks.json', () => {
-	
-	
 	test('Completion for Start application with camel.debug profile', async () => {
 		const docURiTasksJson = getDocUri('.vscode/tasks.json');
 		const expectedCompletion = { label: 'Start Camel application with Maven with camel.debug profile' };
 		await testCompletion(docURiTasksJson, new vscode.Position(3, 7), expectedCompletion);
 	}).timeout(20000);
-	
+
 	test('Completion for Start application with jbang', async () => {
 		const docURiTasksJson = getDocUri('.vscode/tasks.json');
 		const expectedCompletion = { label: 'Run Camel application with JBang with camel-debug' };
 		await testCompletion(docURiTasksJson, new vscode.Position(3, 7), expectedCompletion);
 	}).timeout(20000);
-
 });
 
 async function testCompletion(
@@ -31,11 +28,11 @@ async function testCompletion(
 
 export async function checkExpectedCompletion(docUri: vscode.Uri, position: vscode.Position, expectedCompletion: vscode.CompletionItem) {
 	let hasExpectedCompletion = false;
-	let lastCompletionList : vscode.CompletionList | undefined;
+	let lastCompletionList: vscode.CompletionList | undefined;
 	try {
-		await waitUntil(() => {
+		await waitUntil(async () => {
 			// Executing the command `vscode.executeCompletionItemProvider` to simulate triggering completion
-			(vscode.commands.executeCommand('vscode.executeCompletionItemProvider', docUri, position)).then(value => {
+			await (vscode.commands.executeCommand('vscode.executeCompletionItemProvider', docUri, position)).then(value => {
 				const actualCompletionList = value as vscode.CompletionList;
 				lastCompletionList = actualCompletionList;
 				const completionItemFound = actualCompletionList.items.find(completion => {
@@ -48,7 +45,7 @@ export async function checkExpectedCompletion(docUri: vscode.Uri, position: vsco
 		}, 10000, 500);
 	} catch (err) {
 		let errorMessage = '';
-		if(lastCompletionList) {
+		if (lastCompletionList) {
 			lastCompletionList.items.forEach(completion => {
 				errorMessage += completion.label + '\n';
 			});

--- a/src/ui-test/uitest_runner.ts
+++ b/src/ui-test/uitest_runner.ts
@@ -42,4 +42,6 @@ async function main(): Promise<void> {
 	fs.rmSync(extensionFolder, { recursive: true });
 }
 
-main();
+main().catch((error) => {
+	console.error('Unhandled promise rejection in main: ', error);
+});


### PR DESCRIPTION
Init issues Relate to #461:

**Fixed with added async/await**
~~/home/runner/work/camel-dap-client-vscode/camel-dap-client-vscode/src/extension.ts
Warning: 40:2 warning Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the void operator @typescript-eslint/no-floating-promises
Warning: 72:8 warning Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the void operator @typescript-eslint/no-floating-promises
Warning: 92:2 warning Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the void operator @typescript-eslint/no-floating-promises
Warning: 103:2 warning Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the void operator @typescript-eslint/no-floating-promises~~

**Fixed with catch**
~~/home/runner/work/camel-dap-client-vscode/camel-dap-client-vscode/src/test/runTest.ts
Warning: 48:1 warning Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the void operator @typescript-eslint/no-floating-promises~~

**Fixed with added async/await**
~~/home/runner/work/camel-dap-client-vscode/camel-dap-client-vscode/src/test/suite/completion.task.test.ts
Warning: 38:4 warning Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the void operator @typescript-eslint/no-floating-promises~~

**Fixed with catch**
~~/home/runner/work/camel-dap-client-vscode/camel-dap-client-vscode/src/ui-test/uitest_runner.ts
Warning: 45:1 warning Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the void operator @typescript-eslint/no-floating-promises~~

heavy_multiplication_x 7 problems (0 errors, 7 warnings)

