### PR TITLE
Bump vscode-uitests-tooling from 4.0.3 to 4.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
 				"mocha-jenkins-reporter": "^0.4.8",
 				"mvn-artifact-download": "^6.1.1",
 				"typescript": "^5.1.6",
-				"vscode-uitests-tooling": "^4.0.3"
+				"vscode-uitests-tooling": "^4.0.5"
 			},
 			"engines": {
 				"vscode": "^1.76.0"
@@ -345,9 +345,9 @@
 			"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
 		},
 		"node_modules/@sindresorhus/is": {
-			"version": "5.4.1",
-			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.4.1.tgz",
-			"integrity": "sha512-axlrvsHlHlFmKKMEg4VyvMzFr93JWJj4eIfXY1STVuO2fsImCa7ncaiG5gC8HKOX590AW5RtRsC41/B+OfrSqw==",
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.6.0.tgz",
+			"integrity": "sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==",
 			"dev": true,
 			"engines": {
 				"node": ">=14.16"
@@ -856,9 +856,9 @@
 			}
 		},
 		"node_modules/@vscode/vsce": {
-			"version": "2.19.0",
-			"resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-2.19.0.tgz",
-			"integrity": "sha512-dAlILxC5ggOutcvJY24jxz913wimGiUrHaPkk16Gm9/PGFbz1YezWtrXsTKUtJws4fIlpX2UIlVlVESWq8lkfQ==",
+			"version": "2.20.1",
+			"resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-2.20.1.tgz",
+			"integrity": "sha512-ilbvoqvR/1/zseRPBAzYR6aKqSJ+jvda4/BqIwOqTxajpvLtEpK3kMLs77+dJdrlygS+VrP7Yhad8j0ukyD96g==",
 			"dev": true,
 			"dependencies": {
 				"azure-devops-node-api": "^11.0.1",
@@ -874,7 +874,7 @@
 				"minimatch": "^3.0.3",
 				"parse-semver": "^1.1.1",
 				"read": "^1.0.7",
-				"semver": "^5.1.0",
+				"semver": "^7.5.2",
 				"tmp": "^0.2.1",
 				"typed-rest-client": "^1.8.4",
 				"url-join": "^4.0.1",
@@ -978,15 +978,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=4"
-			}
-		},
-		"node_modules/@vscode/vsce/node_modules/semver": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-			"dev": true,
-			"bin": {
-				"semver": "bin/semver"
 			}
 		},
 		"node_modules/@vscode/vsce/node_modules/supports-color": {
@@ -1183,8 +1174,7 @@
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
 		},
 		"node_modules/base64-js": {
 			"version": "1.5.1",
@@ -1281,7 +1271,6 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dev": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -1389,15 +1378,15 @@
 			}
 		},
 		"node_modules/cacheable-request": {
-			"version": "10.2.12",
-			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.12.tgz",
-			"integrity": "sha512-qtWGB5kn2OLjx47pYUkWicyOpK1vy9XZhq8yRTXOy+KAmjjESSRLx6SiExnnaGGUP1NM6/vmygMu0fGylNh9tw==",
+			"version": "10.2.13",
+			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.13.tgz",
+			"integrity": "sha512-3SD4rrMu1msNGEtNSt8Od6enwdo//U9s4ykmXfA2TD58kcLkCobtCDiby7kNyj7a/Q7lz/mAesAFI54rTdnvBA==",
 			"dev": true,
 			"dependencies": {
 				"@types/http-cache-semantics": "^4.0.1",
 				"get-stream": "^6.0.1",
 				"http-cache-semantics": "^4.1.1",
-				"keyv": "^4.5.2",
+				"keyv": "^4.5.3",
 				"mimic-response": "^4.0.0",
 				"normalize-url": "^8.0.0",
 				"responselike": "^3.0.0"
@@ -1703,22 +1692,20 @@
 			}
 		},
 		"node_modules/compare-versions": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-5.0.3.tgz",
-			"integrity": "sha512-4UZlZP8Z99MGEY+Ovg/uJxJuvoXuN4M6B3hKaiackiHrgzQFEe3diJi1mf1PNHbFujM7FvLrK2bpgIaImbtZ1A==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.0.0.tgz",
+			"integrity": "sha512-s2MzYxfRsE9f/ow8hjn7ysa7pod1xhHdQMsgiJtKx6XSNf4x2N1KG4fjrkUmXcP/e9Y2ZX4zB6sHIso0Lm6evQ==",
 			"dev": true
 		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-			"dev": true
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"node_modules/core-util-is": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-			"dev": true
+			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
 		},
 		"node_modules/countries-and-timezones": {
 			"version": "3.4.1",
@@ -1872,9 +1859,9 @@
 			}
 		},
 		"node_modules/detect-libc": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
-			"integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
+			"integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
 			"dev": true,
 			"optional": true,
 			"engines": {
@@ -2436,8 +2423,7 @@
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-			"dev": true
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"node_modules/fstream": {
 			"version": "1.0.12",
@@ -2877,8 +2863,7 @@
 		"node_modules/immediate": {
 			"version": "3.0.6",
 			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-			"integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
-			"dev": true
+			"integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
 		},
 		"node_modules/import-fresh": {
 			"version": "3.3.0",
@@ -2909,7 +2894,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"dev": true,
 			"dependencies": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -2918,8 +2902,7 @@
 		"node_modules/inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
 		"node_modules/ini": {
 			"version": "1.3.8",
@@ -3073,8 +3056,7 @@
 		"node_modules/isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-			"dev": true
+			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
 		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
@@ -3159,7 +3141,6 @@
 			"version": "3.10.1",
 			"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
 			"integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
-			"dev": true,
 			"dependencies": {
 				"lie": "~3.3.0",
 				"pako": "~1.0.2",
@@ -3180,9 +3161,9 @@
 			}
 		},
 		"node_modules/keyv": {
-			"version": "4.5.2",
-			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.2.tgz",
-			"integrity": "sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==",
+			"version": "4.5.3",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.3.tgz",
+			"integrity": "sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==",
 			"dev": true,
 			"dependencies": {
 				"json-buffer": "3.0.1"
@@ -3234,7 +3215,6 @@
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
 			"integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-			"dev": true,
 			"dependencies": {
 				"immediate": "~3.0.5"
 			}
@@ -3461,7 +3441,6 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
 			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dev": true,
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -3656,14 +3635,14 @@
 			}
 		},
 		"node_modules/monaco-page-objects": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/monaco-page-objects/-/monaco-page-objects-3.8.0.tgz",
-			"integrity": "sha512-/bsrTHul7KsZ1SmdQFHIdVZTU2Nr+odGpxZAJddWxanX1uEAreqE4H758wI9Ie3mZLFO798lPjv2zaUAi+kDFw==",
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/monaco-page-objects/-/monaco-page-objects-3.9.0.tgz",
+			"integrity": "sha512-Hw5eJqYAhe/a83xziiIU113RVZ7vUOdyNCPxgjVN+JcKjuLzqgQcSRY0NRnQzfMmckpNUpNfcx6o1nKkiPZv4g==",
 			"dev": true,
 			"dependencies": {
 				"clipboardy": "^3.0.0",
 				"clone-deep": "^4.0.1",
-				"compare-versions": "^5.0.3",
+				"compare-versions": "^6.0.0",
 				"fs-extra": "^11.1.1",
 				"ts-essentials": "^9.3.2"
 			},
@@ -3969,8 +3948,7 @@
 		"node_modules/pako": {
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-			"dev": true
+			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
 		},
 		"node_modules/parent-module": {
 			"version": "1.0.1",
@@ -3994,9 +3972,9 @@
 			}
 		},
 		"node_modules/parse-semver/node_modules/semver": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+			"version": "5.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
 			"dev": true,
 			"bin": {
 				"semver": "bin/semver"
@@ -4040,7 +4018,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -4152,8 +4129,7 @@
 		"node_modules/process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-			"dev": true
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
 		},
 		"node_modules/proxy-from-env": {
 			"version": "1.1.0",
@@ -4276,7 +4252,6 @@
 			"version": "2.3.7",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
 			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-			"dev": true,
 			"dependencies": {
 				"core-util-is": "~1.0.0",
 				"inherits": "~2.0.3",
@@ -4352,7 +4327,6 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
 			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-			"dev": true,
 			"dependencies": {
 				"glob": "^7.1.3"
 			},
@@ -4367,7 +4341,6 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
 			"integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-			"dev": true,
 			"dependencies": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -4409,8 +4382,7 @@
 		"node_modules/safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
 		"node_modules/sanitize-filename": {
 			"version": "1.6.3",
@@ -4431,7 +4403,6 @@
 			"version": "4.10.0",
 			"resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.10.0.tgz",
 			"integrity": "sha512-hSQPw6jgc+ej/UEcdQPG/iBwwMeCEgZr9HByY/J8ToyXztEqXzU9aLsIyrlj1BywBcStO4JQK/zMUWWrV8+riA==",
-			"dev": true,
 			"dependencies": {
 				"jszip": "^3.10.1",
 				"tmp": "^0.2.1",
@@ -4468,8 +4439,7 @@
 		"node_modules/setimmediate": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-			"dev": true
+			"integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
 		},
 		"node_modules/shallow-clone": {
 			"version": "3.0.1",
@@ -4581,7 +4551,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
 			"dependencies": {
 				"safe-buffer": "~5.1.0"
 			}
@@ -4786,7 +4755,6 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
 			"integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
-			"dev": true,
 			"dependencies": {
 				"rimraf": "^3.0.0"
 			},
@@ -4921,9 +4889,9 @@
 			}
 		},
 		"node_modules/typed-rest-client": {
-			"version": "1.8.9",
-			"resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.9.tgz",
-			"integrity": "sha512-uSmjE38B80wjL85UFX3sTYEUlvZ1JgCRhsWj/fJ4rZ0FqDUFoIuodtiVeE+cUqiVTOKPdKrp/sdftD15MDek6g==",
+			"version": "1.8.11",
+			"resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.11.tgz",
+			"integrity": "sha512-5UvfMpd1oelmUPRbbaVnq+rHP7ng2cE4qoQkQeAqxRL6PklkxsM0g32/HL0yfvruK6ojQ5x8EE+HF4YV6DtuCA==",
 			"dev": true,
 			"dependencies": {
 				"qs": "^6.9.1",
@@ -5025,8 +4993,7 @@
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-			"dev": true
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
 		},
 		"node_modules/uuid": {
 			"version": "9.0.0",
@@ -5037,26 +5004,26 @@
 			}
 		},
 		"node_modules/vscode-extension-tester": {
-			"version": "5.8.0",
-			"resolved": "https://registry.npmjs.org/vscode-extension-tester/-/vscode-extension-tester-5.8.0.tgz",
-			"integrity": "sha512-DMOSmxXnrREWqLXYYq+Au53n6/BAVbKbOPxAm7bmpuvMCyF6lKJk9olEsbbVMTugkIToLaafsh4LSq47bTgeHQ==",
+			"version": "5.9.0",
+			"resolved": "https://registry.npmjs.org/vscode-extension-tester/-/vscode-extension-tester-5.9.0.tgz",
+			"integrity": "sha512-VMmq/fB6FyXK+ICeQpnZa+JeAuCZy9Xz1mo90iw8/eNZEjTYlZqfMSMBGMIJ0vvnHAf5XjEaemPte9JESmsoSw==",
 			"dev": true,
 			"dependencies": {
-				"@types/selenium-webdriver": "^4.1.12",
-				"@vscode/vsce": "^2.19.0",
+				"@types/selenium-webdriver": "^4.1.15",
+				"@vscode/vsce": "^2.20.0",
 				"commander": "^11.0.0",
-				"compare-versions": "^5.0.1",
+				"compare-versions": "^6.0.0",
 				"fs-extra": "^11.1.0",
 				"glob": "^8.1.0",
 				"got": "^13.0.0",
 				"hpagent": "^1.2.0",
 				"js-yaml": "^4.1.0",
-				"monaco-page-objects": "^3.8.0",
+				"monaco-page-objects": "^3.9.0",
 				"sanitize-filename": "^1.6.3",
 				"selenium-webdriver": "^4.10.0",
 				"targz": "^1.0.1",
 				"unzipper": "^0.10.14",
-				"vscode-extension-tester-locators": "^3.6.0"
+				"vscode-extension-tester-locators": "^3.7.0"
 			},
 			"bin": {
 				"extest": "out/cli.js"
@@ -5067,12 +5034,12 @@
 			}
 		},
 		"node_modules/vscode-extension-tester-locators": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/vscode-extension-tester-locators/-/vscode-extension-tester-locators-3.6.0.tgz",
-			"integrity": "sha512-RjQf5XL33dJORl9ck5X0vhAHf93TOONPE4nb9nai/pDM15nYcD1TqMyzRGl/XxHpvBu/bP8MV/bHfCT6b8w2cQ==",
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/vscode-extension-tester-locators/-/vscode-extension-tester-locators-3.7.0.tgz",
+			"integrity": "sha512-ML9RFOum8GoE4xggYNzUIanFOT4CWUDCK5LFraLEoJ+9rptA5PSLGC+uSPYVKNNU2pG946SPEC3ZJDetc/IeqA==",
 			"dev": true,
 			"peerDependencies": {
-				"monaco-page-objects": "^3.8.0",
+				"monaco-page-objects": "^3.9.0",
 				"selenium-webdriver": "^4.6.1"
 			}
 		},
@@ -5117,9 +5084,9 @@
 			}
 		},
 		"node_modules/vscode-uitests-tooling": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/vscode-uitests-tooling/-/vscode-uitests-tooling-4.0.3.tgz",
-			"integrity": "sha512-aVE/gDrRABIhbfVba9RXG1fZ+5nCLfmlNdhU9IWsFxA31uC3kXnRt7HXaJXMH35hjqKNJ+wCtaUZ7g9BRYKytA==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/vscode-uitests-tooling/-/vscode-uitests-tooling-4.0.5.tgz",
+			"integrity": "sha512-GZvB/kTDrce7BGeFebhX+Ta967w457ByMoAcAxIWWUGhCBC7X+ahX4PRhzFAwxlNI5NED6mDpqBssOd9chP55Q==",
 			"dev": true,
 			"dependencies": {
 				"chai": "^4.3.7",
@@ -5127,7 +5094,7 @@
 				"fs-extra": "^11.1.1",
 				"sanitize-filename": "^1.6.3",
 				"tree-kill": "^1.2.2",
-				"vscode-extension-tester": "^5.8.0"
+				"vscode-extension-tester": "^5.9.0"
 			},
 			"peerDependencies": {
 				"mocha": ">=5.2.0"
@@ -5211,7 +5178,6 @@
 			"version": "8.13.0",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
 			"integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-			"dev": true,
 			"engines": {
 				"node": ">=10.0.0"
 			},
@@ -5585,9 +5551,9 @@
 			}
 		},
 		"@sindresorhus/is": {
-			"version": "5.4.1",
-			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.4.1.tgz",
-			"integrity": "sha512-axlrvsHlHlFmKKMEg4VyvMzFr93JWJj4eIfXY1STVuO2fsImCa7ncaiG5gC8HKOX590AW5RtRsC41/B+OfrSqw==",
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.6.0.tgz",
+			"integrity": "sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==",
 			"dev": true
 		},
 		"@szmarczak/http-timer": {
@@ -5918,9 +5884,9 @@
 			}
 		},
 		"@vscode/vsce": {
-			"version": "2.19.0",
-			"resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-2.19.0.tgz",
-			"integrity": "sha512-dAlILxC5ggOutcvJY24jxz913wimGiUrHaPkk16Gm9/PGFbz1YezWtrXsTKUtJws4fIlpX2UIlVlVESWq8lkfQ==",
+			"version": "2.20.1",
+			"resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-2.20.1.tgz",
+			"integrity": "sha512-ilbvoqvR/1/zseRPBAzYR6aKqSJ+jvda4/BqIwOqTxajpvLtEpK3kMLs77+dJdrlygS+VrP7Yhad8j0ukyD96g==",
 			"dev": true,
 			"requires": {
 				"azure-devops-node-api": "^11.0.1",
@@ -5937,7 +5903,7 @@
 				"minimatch": "^3.0.3",
 				"parse-semver": "^1.1.1",
 				"read": "^1.0.7",
-				"semver": "^5.1.0",
+				"semver": "^7.5.2",
 				"tmp": "^0.2.1",
 				"typed-rest-client": "^1.8.4",
 				"url-join": "^4.0.1",
@@ -6011,12 +5977,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
 					"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-					"dev": true
-				},
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
 					"dev": true
 				},
 				"supports-color": {
@@ -6158,8 +6118,7 @@
 		"balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
 		},
 		"base64-js": {
 			"version": "1.5.1",
@@ -6232,7 +6191,6 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -6311,15 +6269,15 @@
 			"dev": true
 		},
 		"cacheable-request": {
-			"version": "10.2.12",
-			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.12.tgz",
-			"integrity": "sha512-qtWGB5kn2OLjx47pYUkWicyOpK1vy9XZhq8yRTXOy+KAmjjESSRLx6SiExnnaGGUP1NM6/vmygMu0fGylNh9tw==",
+			"version": "10.2.13",
+			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.13.tgz",
+			"integrity": "sha512-3SD4rrMu1msNGEtNSt8Od6enwdo//U9s4ykmXfA2TD58kcLkCobtCDiby7kNyj7a/Q7lz/mAesAFI54rTdnvBA==",
 			"dev": true,
 			"requires": {
 				"@types/http-cache-semantics": "^4.0.1",
 				"get-stream": "^6.0.1",
 				"http-cache-semantics": "^4.1.1",
-				"keyv": "^4.5.2",
+				"keyv": "^4.5.3",
 				"mimic-response": "^4.0.0",
 				"normalize-url": "^8.0.0",
 				"responselike": "^3.0.0"
@@ -6540,22 +6498,20 @@
 			"dev": true
 		},
 		"compare-versions": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-5.0.3.tgz",
-			"integrity": "sha512-4UZlZP8Z99MGEY+Ovg/uJxJuvoXuN4M6B3hKaiackiHrgzQFEe3diJi1mf1PNHbFujM7FvLrK2bpgIaImbtZ1A==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.0.0.tgz",
+			"integrity": "sha512-s2MzYxfRsE9f/ow8hjn7ysa7pod1xhHdQMsgiJtKx6XSNf4x2N1KG4fjrkUmXcP/e9Y2ZX4zB6sHIso0Lm6evQ==",
 			"dev": true
 		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-			"dev": true
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"core-util-is": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-			"dev": true
+			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
 		},
 		"countries-and-timezones": {
 			"version": "3.4.1",
@@ -6657,9 +6613,9 @@
 			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
 		},
 		"detect-libc": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
-			"integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
+			"integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
 			"dev": true,
 			"optional": true
 		},
@@ -7070,8 +7026,7 @@
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-			"dev": true
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fstream": {
 			"version": "1.0.12",
@@ -7385,8 +7340,7 @@
 		"immediate": {
 			"version": "3.0.6",
 			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-			"integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
-			"dev": true
+			"integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
 		},
 		"import-fresh": {
 			"version": "3.3.0",
@@ -7408,7 +7362,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"dev": true,
 			"requires": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -7417,8 +7370,7 @@
 		"inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
 		"ini": {
 			"version": "1.3.8",
@@ -7518,8 +7470,7 @@
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-			"dev": true
+			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -7588,7 +7539,6 @@
 			"version": "3.10.1",
 			"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
 			"integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
-			"dev": true,
 			"requires": {
 				"lie": "~3.3.0",
 				"pako": "~1.0.2",
@@ -7608,9 +7558,9 @@
 			}
 		},
 		"keyv": {
-			"version": "4.5.2",
-			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.2.tgz",
-			"integrity": "sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==",
+			"version": "4.5.3",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.3.tgz",
+			"integrity": "sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==",
 			"dev": true,
 			"requires": {
 				"json-buffer": "3.0.1"
@@ -7650,7 +7600,6 @@
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
 			"integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-			"dev": true,
 			"requires": {
 				"immediate": "~3.0.5"
 			}
@@ -7819,7 +7768,6 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
 			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
@@ -7969,14 +7917,14 @@
 			}
 		},
 		"monaco-page-objects": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/monaco-page-objects/-/monaco-page-objects-3.8.0.tgz",
-			"integrity": "sha512-/bsrTHul7KsZ1SmdQFHIdVZTU2Nr+odGpxZAJddWxanX1uEAreqE4H758wI9Ie3mZLFO798lPjv2zaUAi+kDFw==",
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/monaco-page-objects/-/monaco-page-objects-3.9.0.tgz",
+			"integrity": "sha512-Hw5eJqYAhe/a83xziiIU113RVZ7vUOdyNCPxgjVN+JcKjuLzqgQcSRY0NRnQzfMmckpNUpNfcx6o1nKkiPZv4g==",
 			"dev": true,
 			"requires": {
 				"clipboardy": "^3.0.0",
 				"clone-deep": "^4.0.1",
-				"compare-versions": "^5.0.3",
+				"compare-versions": "^6.0.0",
 				"fs-extra": "^11.1.1",
 				"ts-essentials": "^9.3.2"
 			}
@@ -8189,8 +8137,7 @@
 		"pako": {
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-			"dev": true
+			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
 		},
 		"parent-module": {
 			"version": "1.0.1",
@@ -8211,9 +8158,9 @@
 			},
 			"dependencies": {
 				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"version": "5.7.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+					"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
 					"dev": true
 				}
 			}
@@ -8246,8 +8193,7 @@
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"dev": true
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 		},
 		"path-key": {
 			"version": "3.1.1",
@@ -8325,8 +8271,7 @@
 		"process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-			"dev": true
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
 		},
 		"proxy-from-env": {
 			"version": "1.1.0",
@@ -8413,7 +8358,6 @@
 			"version": "2.3.7",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
 			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-			"dev": true,
 			"requires": {
 				"core-util-is": "~1.0.0",
 				"inherits": "~2.0.3",
@@ -8470,7 +8414,6 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
 			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-			"dev": true,
 			"requires": {
 				"glob": "^7.1.3"
 			},
@@ -8479,7 +8422,6 @@
 					"version": "7.2.0",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
 					"integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-					"dev": true,
 					"requires": {
 						"fs.realpath": "^1.0.0",
 						"inflight": "^1.0.4",
@@ -8503,8 +8445,7 @@
 		"safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
 		"sanitize-filename": {
 			"version": "1.6.3",
@@ -8525,7 +8466,6 @@
 			"version": "4.10.0",
 			"resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.10.0.tgz",
 			"integrity": "sha512-hSQPw6jgc+ej/UEcdQPG/iBwwMeCEgZr9HByY/J8ToyXztEqXzU9aLsIyrlj1BywBcStO4JQK/zMUWWrV8+riA==",
-			"dev": true,
 			"requires": {
 				"jszip": "^3.10.1",
 				"tmp": "^0.2.1",
@@ -8553,8 +8493,7 @@
 		"setimmediate": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-			"dev": true
+			"integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
 		},
 		"shallow-clone": {
 			"version": "3.0.1",
@@ -8623,7 +8562,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.1.0"
 			}
@@ -8797,7 +8735,6 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
 			"integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
-			"dev": true,
 			"requires": {
 				"rimraf": "^3.0.0"
 			}
@@ -8895,9 +8832,9 @@
 			"dev": true
 		},
 		"typed-rest-client": {
-			"version": "1.8.9",
-			"resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.9.tgz",
-			"integrity": "sha512-uSmjE38B80wjL85UFX3sTYEUlvZ1JgCRhsWj/fJ4rZ0FqDUFoIuodtiVeE+cUqiVTOKPdKrp/sdftD15MDek6g==",
+			"version": "1.8.11",
+			"resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.11.tgz",
+			"integrity": "sha512-5UvfMpd1oelmUPRbbaVnq+rHP7ng2cE4qoQkQeAqxRL6PklkxsM0g32/HL0yfvruK6ojQ5x8EE+HF4YV6DtuCA==",
 			"dev": true,
 			"requires": {
 				"qs": "^6.9.1",
@@ -8976,8 +8913,7 @@
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-			"dev": true
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
 		},
 		"uuid": {
 			"version": "9.0.0",
@@ -8985,26 +8921,26 @@
 			"integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
 		},
 		"vscode-extension-tester": {
-			"version": "5.8.0",
-			"resolved": "https://registry.npmjs.org/vscode-extension-tester/-/vscode-extension-tester-5.8.0.tgz",
-			"integrity": "sha512-DMOSmxXnrREWqLXYYq+Au53n6/BAVbKbOPxAm7bmpuvMCyF6lKJk9olEsbbVMTugkIToLaafsh4LSq47bTgeHQ==",
+			"version": "5.9.0",
+			"resolved": "https://registry.npmjs.org/vscode-extension-tester/-/vscode-extension-tester-5.9.0.tgz",
+			"integrity": "sha512-VMmq/fB6FyXK+ICeQpnZa+JeAuCZy9Xz1mo90iw8/eNZEjTYlZqfMSMBGMIJ0vvnHAf5XjEaemPte9JESmsoSw==",
 			"dev": true,
 			"requires": {
-				"@types/selenium-webdriver": "^4.1.12",
-				"@vscode/vsce": "^2.19.0",
+				"@types/selenium-webdriver": "^4.1.15",
+				"@vscode/vsce": "^2.20.0",
 				"commander": "^11.0.0",
-				"compare-versions": "^5.0.1",
+				"compare-versions": "^6.0.0",
 				"fs-extra": "^11.1.0",
 				"glob": "^8.1.0",
 				"got": "^13.0.0",
 				"hpagent": "^1.2.0",
 				"js-yaml": "^4.1.0",
-				"monaco-page-objects": "^3.8.0",
+				"monaco-page-objects": "^3.9.0",
 				"sanitize-filename": "^1.6.3",
 				"selenium-webdriver": "^4.10.0",
 				"targz": "^1.0.1",
 				"unzipper": "^0.10.14",
-				"vscode-extension-tester-locators": "^3.6.0"
+				"vscode-extension-tester-locators": "^3.7.0"
 			},
 			"dependencies": {
 				"brace-expansion": {
@@ -9041,16 +8977,16 @@
 			}
 		},
 		"vscode-extension-tester-locators": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/vscode-extension-tester-locators/-/vscode-extension-tester-locators-3.6.0.tgz",
-			"integrity": "sha512-RjQf5XL33dJORl9ck5X0vhAHf93TOONPE4nb9nai/pDM15nYcD1TqMyzRGl/XxHpvBu/bP8MV/bHfCT6b8w2cQ==",
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/vscode-extension-tester-locators/-/vscode-extension-tester-locators-3.7.0.tgz",
+			"integrity": "sha512-ML9RFOum8GoE4xggYNzUIanFOT4CWUDCK5LFraLEoJ+9rptA5PSLGC+uSPYVKNNU2pG946SPEC3ZJDetc/IeqA==",
 			"dev": true,
 			"requires": {}
 		},
 		"vscode-uitests-tooling": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/vscode-uitests-tooling/-/vscode-uitests-tooling-4.0.3.tgz",
-			"integrity": "sha512-aVE/gDrRABIhbfVba9RXG1fZ+5nCLfmlNdhU9IWsFxA31uC3kXnRt7HXaJXMH35hjqKNJ+wCtaUZ7g9BRYKytA==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/vscode-uitests-tooling/-/vscode-uitests-tooling-4.0.5.tgz",
+			"integrity": "sha512-GZvB/kTDrce7BGeFebhX+Ta967w457ByMoAcAxIWWUGhCBC7X+ahX4PRhzFAwxlNI5NED6mDpqBssOd9chP55Q==",
 			"dev": true,
 			"requires": {
 				"chai": "^4.3.7",
@@ -9058,7 +8994,7 @@
 				"fs-extra": "^11.1.1",
 				"sanitize-filename": "^1.6.3",
 				"tree-kill": "^1.2.2",
-				"vscode-extension-tester": "^5.8.0"
+				"vscode-extension-tester": "^5.9.0"
 			}
 		},
 		"webidl-conversions": {
@@ -9120,7 +9056,6 @@
 			"version": "8.13.0",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
 			"integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-			"dev": true,
 			"requires": {}
 		},
 		"xml": {

--- a/package.json
+++ b/package.json
@@ -237,7 +237,7 @@
 		"mocha-jenkins-reporter": "^0.4.8",
 		"mvn-artifact-download": "^6.1.1",
 		"typescript": "^5.1.6",
-		"vscode-uitests-tooling": "^4.0.3"
+		"vscode-uitests-tooling": "^4.0.5"
 	},
 	"dependencies": {
 		"@redhat-developer/vscode-redhat-telemetry": "^0.6.1",


### PR DESCRIPTION
I have accidentally closed PR #463, so it is the replacement for it

With bump I have added:

- debugger test refactoring with new extester features 
- added disable/enable breakpoint -> here was found a bug https://issues.redhat.com/browse/FUSETOOLS2-2162, so tests are skipped for now