### PR TITLE
Fix Command Quotation issue

### DIFF
--- a/src/task/CamelJBangTaskProvider.ts
+++ b/src/task/CamelJBangTaskProvider.ts
@@ -17,13 +17,13 @@
 import { CancellationToken, ProviderResult, ShellExecution, Task, TaskDefinition, TaskProvider, TaskRevealKind, TaskScope, workspace } from 'vscode';
 
 export class CamelJBangTaskProvider implements TaskProvider {
-	
-	public static labelProvidedTask :string = "Start Camel application with debug enabled with JBang";
+
+	public static labelProvidedTask: string = "Start Camel application with debug enabled with JBang";
 	public static labelProvidedRunTask: string = "Run Camel application with JBang";
-	
+
 	provideTasks(token: CancellationToken): ProviderResult<Task[]> {
 		const tasks: Task[] = [];
-		const taskDefinition :TaskDefinition = {
+		const taskDefinition: TaskDefinition = {
 			"label": CamelJBangTaskProvider.labelProvidedTask,
 			"type": "shell"
 		};
@@ -33,8 +33,28 @@ export class CamelJBangTaskProvider implements TaskProvider {
 			TaskScope.Workspace,
 			CamelJBangTaskProvider.labelProvidedTask,
 			'camel',
-			new ShellExecution(`jbang \'-Dorg.apache.camel.debugger.suspend=true\' \'-Dcamel.jbang.version=${this.getCamelJBangCLIVersion()}\' camel@apache/camel run \'\${relativeFile}\' --logging-level=info \'--dep=org.apache.camel:camel-debug\' ${this.getCamelVersion()}`),
-			'$camel.debug.problemMatcher');
+			new ShellExecution(
+				'jbang',
+				[
+					{
+						"value": `-Dcamel.jbang.version=${this.getCamelJBangCLIVersion()}`,
+						"quoting": 2
+					},
+					{
+						"value": '-Dorg.apache.camel.debugger.suspend=true',
+						"quoting": 2
+					},
+					'camel@apache/camel',
+					'run',
+					'${relativeFile}',
+					'--dev',
+					'--logging-level=info',
+					'--dep=org.apache.camel:camel-debug',
+					`${this.getCamelVersion()}`
+				]
+			),
+			'$camel.debug.problemMatcher'
+		);
 		task.isBackground = true;
 		task.presentationOptions.reveal = TaskRevealKind.Always;
 
@@ -46,7 +66,21 @@ export class CamelJBangTaskProvider implements TaskProvider {
 			TaskScope.Workspace,
 			CamelJBangTaskProvider.labelProvidedRunTask,
 			'camel',
-			new ShellExecution(`jbang \'-Dcamel.jbang.version=${this.getCamelJBangCLIVersion()}\' camel@apache/camel run \'\${relativeFile}\' --dev --logging-level=info ${this.getCamelVersion()}`)
+			new ShellExecution(
+				'jbang',
+				[
+					{
+						"value": `-Dcamel.jbang.version=${this.getCamelJBangCLIVersion()}`,
+						"quoting": 2
+					},
+					'camel@apache/camel',
+					'run',
+					'${relativeFile}',
+					'--dev',
+					'--logging-level=info',
+					`${this.getCamelVersion()}`
+				]
+			)
 		);
 		runTask.isBackground = true;
 
@@ -54,7 +88,7 @@ export class CamelJBangTaskProvider implements TaskProvider {
 		tasks.push(runTask);
 		return tasks;
 	}
-	
+
 	resolveTask(task: Task, token: CancellationToken): ProviderResult<Task> {
 		return undefined;
 	}
@@ -65,7 +99,7 @@ export class CamelJBangTaskProvider implements TaskProvider {
 
 	private getCamelVersion(): string {
 		const camelVersion = workspace.getConfiguration().get('camel.debugAdapter.CamelVersion') as string;
-		if(camelVersion) {
+		if (camelVersion) {
 			return `--camel-version=${camelVersion}`;
 		} else {
 			return '';

--- a/src/test/suite/camel.jbang.version.settings.test.ts
+++ b/src/test/suite/camel.jbang.version.settings.test.ts
@@ -16,10 +16,10 @@
  */
 'use strict';
 
-import { workspace } from 'vscode';
+import { ShellQuotedString, workspace } from 'vscode';
 import { CamelJBangTaskProvider } from '../../task/CamelJBangTaskProvider';
 import { expect } from 'chai';
-import { getCamelTask, getTaskCommandLine } from './util';
+import { getCamelTask, getTaskCommandArguments } from './util';
 
 suite('Should run commands with Camel JBang version specified in settings', () => {
 
@@ -47,7 +47,7 @@ suite('Should run commands with Camel JBang version specified in settings', () =
 		await config.update(CAMEL_JBANG_VERSION_SETTINGS_ID, CAMEL_JBANG_VERSION);
 
 		const camelRunTask = await getCamelTask(CamelJBangTaskProvider.labelProvidedRunTask);
-		expect(getTaskCommandLine(camelRunTask)).to.includes(CAMEL_JBANG_VERSION);
+		expect((getTaskCommandArguments(camelRunTask)![0] as ShellQuotedString).value).to.includes(CAMEL_JBANG_VERSION);
 	});
 
 	test('Updated Camel JBang version is correct in generated \'Run and Debug with JBang\' task', async function () {
@@ -57,7 +57,7 @@ suite('Should run commands with Camel JBang version specified in settings', () =
 		await config.update(CAMEL_JBANG_VERSION_SETTINGS_ID, CAMEL_JBANG_VERSION);
 
 		const camelRunAndDebugTask = await getCamelTask(CamelJBangTaskProvider.labelProvidedTask);
-		expect(getTaskCommandLine(camelRunAndDebugTask)).to.includes(CAMEL_JBANG_VERSION);
+		expect((getTaskCommandArguments(camelRunAndDebugTask)![0] as ShellQuotedString).value).to.includes(CAMEL_JBANG_VERSION);
 	});
 
 });

--- a/src/test/suite/camel.version.settings.test.ts
+++ b/src/test/suite/camel.version.settings.test.ts
@@ -19,7 +19,7 @@
 import { workspace } from 'vscode';
 import { CamelJBangTaskProvider } from '../../task/CamelJBangTaskProvider';
 import { expect } from 'chai';
-import { getCamelTask, getTaskCommandLine } from './util';
+import { getCamelTask, getTaskCommandArguments } from './util';
 
 suite('Should run commands with Camel version specified in settings', () => {
 
@@ -40,14 +40,14 @@ suite('Should run commands with Camel version specified in settings', () => {
 		expect(workspace.getConfiguration().get(CAMEL_VERSION_SETTINGS_ID)).to.be.empty;
 	});
 
-    test('Default Camel version in commands is same as Camel JBang CLI default version', async function () {
-        const defaultJBangVersion = workspace.getConfiguration().get('camel.debugAdapter.JBangVersion') as string;
+	test('Default Camel version in commands is same as Camel JBang CLI default version', async function () {
+		const defaultJBangVersion = workspace.getConfiguration().get('camel.debugAdapter.JBangVersion') as string;
 
-        const camelRunTask = await getCamelTask(CamelJBangTaskProvider.labelProvidedRunTask);
-		expect(getTaskCommandLine(camelRunTask)).to.not.includes(`--camel-version=${defaultJBangVersion}`);
+		const camelRunTask = await getCamelTask(CamelJBangTaskProvider.labelProvidedRunTask);
+		expect(getTaskCommandArguments(camelRunTask)).to.not.includes(`--camel-version=${defaultJBangVersion}`);
 
-        const camelRunAndDebugTask = await getCamelTask(CamelJBangTaskProvider.labelProvidedTask);
-		expect(getTaskCommandLine(camelRunAndDebugTask)).to.not.includes(`--camel-version=${defaultJBangVersion}`);
+		const camelRunAndDebugTask = await getCamelTask(CamelJBangTaskProvider.labelProvidedTask);
+		expect(getTaskCommandArguments(camelRunAndDebugTask)).to.not.includes(`--camel-version=${defaultJBangVersion}`);
 	});
 
 	test('Updated Camel version is correct in generated \'Run with JBang\' task', async function () {
@@ -57,7 +57,7 @@ suite('Should run commands with Camel version specified in settings', () => {
 		await config.update(CAMEL_VERSION_SETTINGS_ID, CAMEL_VERSION);
 
 		const camelRunTask = await getCamelTask(CamelJBangTaskProvider.labelProvidedRunTask);
-		expect(getTaskCommandLine(camelRunTask)).to.includes(`--camel-version=${CAMEL_VERSION}`);
+		expect(getTaskCommandArguments(camelRunTask)).to.includes(`--camel-version=${CAMEL_VERSION}`);
 	});
 
 	test('Updated Camel version is correct in generated \'Run and Debug with JBang\' task', async function () {
@@ -67,7 +67,7 @@ suite('Should run commands with Camel version specified in settings', () => {
 		await config.update(CAMEL_VERSION_SETTINGS_ID, CAMEL_VERSION);
 
 		const camelRunAndDebugTask = await getCamelTask(CamelJBangTaskProvider.labelProvidedTask);
-		expect(getTaskCommandLine(camelRunAndDebugTask)).to.includes(`--camel-version=${CAMEL_VERSION}`);
+		expect(getTaskCommandArguments(camelRunAndDebugTask)).to.includes(`--camel-version=${CAMEL_VERSION}`);
 	});
 
 });

--- a/src/test/suite/util.ts
+++ b/src/test/suite/util.ts
@@ -29,6 +29,6 @@ export async function getCamelTask(name: string): Promise<vscode.Task> {
 	return (await vscode.tasks.fetchTasks()).find((t) => t.name === name) as vscode.Task;
 }
 
-export function getTaskCommandLine(task: vscode.Task): string | undefined {
-	return (task.execution as vscode.ShellExecution).commandLine;
+export function getTaskCommandArguments(task: vscode.Task): (string | vscode.ShellQuotedString)[] | undefined {
+	return (task.execution as vscode.ShellExecution).args;
 }


### PR DESCRIPTION
The main problem is that `cmd` support a single quotation and if `cmd` was chosen as the default shell for VS Code, dap commands will fail.

fix #467 

Commands will be (Run):

- **WINDOWS-CMD**: jbang "-Dcamel.jbang.version=3.21.0" camel@apache/camel run "demo route.camel.yaml" --dev --logging-level=info 
- **WINDOWS-PS**/**MACOS**/**Linux**: jbang '-Dcamel.jbang.version=3.21.0' camel@apache/camel run 'demo route.camel.yaml' --dev --logging-level=info

The actual change in command structure will always add appropriate quoting (single/double) to maven pipeline arguments and always add appropriate quoting to file argument in case space in it.