### PR TITLE
FUSETOOLS2-2242: Collect ui-tests screenshoots and logs when cancelled

### DIFF
--- a/.github/workflows/insider.yaml
+++ b/.github/workflows/insider.yaml
@@ -105,14 +105,24 @@ jobs:
 
       - name: Store UI test log
         uses: actions/upload-artifact@v3
-        if: failure() && (steps.uiTest_Ubuntu.outcome == 'failure' || steps.uiTest_MacOS_Windows.outcome == 'failure')
+        if: |
+          (failure() || cancelled()) &&
+          (steps.uiTest_Ubuntu.outcome == 'failure' ||
+          steps.uiTest_MacOS_Windows.outcome == 'failure' ||
+          steps.uiTest_Ubuntu.outcome == 'cancelled' ||
+          steps.uiTest_MacOS_Windows.outcome == 'cancelled')
         with:
           name: ${{ matrix.os }}-${{ matrix.version }}-ui-test-logs
           path: test-resources/settings/logs/*
 
       - name: Store UI Test Screenshots
         uses: actions/upload-artifact@v3
-        if: failure() && (steps.uiTest_Ubuntu.outcome == 'failure' || steps.uiTest_MacOS_Windows.outcome == 'failure')
+        if: |
+          (failure() || cancelled()) &&
+          (steps.uiTest_Ubuntu.outcome == 'failure' ||
+          steps.uiTest_MacOS_Windows.outcome == 'failure' ||
+          steps.uiTest_Ubuntu.outcome == 'cancelled' ||
+          steps.uiTest_MacOS_Windows.outcome == 'cancelled')
         with:
           name: ${{ matrix.os }}-${{ matrix.version }}-ui-test-screenshots
           path: test-resources/screenshots/*.png

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -100,6 +100,7 @@ jobs:
         with:
           name: sbom
           path: manifest.json
+
       - name: Store VS Code Logs (Ubuntu)
         uses: actions/upload-artifact@v3
         if: failure() && matrix.os == 'ubuntu-latest'
@@ -123,14 +124,24 @@ jobs:
 
       - name: Store UI test log
         uses: actions/upload-artifact@v3
-        if: failure() && (steps.uiTest_Ubuntu.outcome == 'failure' || steps.uiTest_MacOS_Windows.outcome == 'failure')
+        if: |
+          (failure() || cancelled()) &&
+          (steps.uiTest_Ubuntu.outcome == 'failure' ||
+          steps.uiTest_MacOS_Windows.outcome == 'failure' ||
+          steps.uiTest_Ubuntu.outcome == 'cancelled' ||
+          steps.uiTest_MacOS_Windows.outcome == 'cancelled')
         with:
           name: ${{ matrix.os }}-${{ matrix.version }}-ui-test-logs
           path: test-resources/settings/logs/*
 
       - name: Store UI Test Screenshots
         uses: actions/upload-artifact@v3
-        if: failure() && (steps.uiTest_Ubuntu.outcome == 'failure' || steps.uiTest_MacOS_Windows.outcome == 'failure')
+        if: |
+          (failure() || cancelled()) &&
+          (steps.uiTest_Ubuntu.outcome == 'failure' ||
+          steps.uiTest_MacOS_Windows.outcome == 'failure' ||
+          steps.uiTest_Ubuntu.outcome == 'cancelled' ||
+          steps.uiTest_MacOS_Windows.outcome == 'cancelled')
         with:
           name: ${{ matrix.os }}-${{ matrix.version }}-ui-test-screenshots
           path: test-resources/screenshots/*.png


### PR DESCRIPTION
Will help with some after all loops issues (https://github.com/camel-tooling/camel-dap-client-vscode/pull/521)

UI test cancelled: 
![Screenshot from 2023-10-23 11-56-58](https://github.com/camel-tooling/camel-dap-client-vscode/assets/46084942/ecaace7d-511b-474b-9c49-1269373778a6)

UI test success:
![Screenshot from 2023-10-23 11-57-57](https://github.com/camel-tooling/camel-dap-client-vscode/assets/46084942/e069d0b8-7628-467d-a84e-d5b55d836349)
