### PR TITLE
FUSETOOLS2-2267: Switch GitHub actions jobs to use directly 'macos-13' runner label

### DIFF
--- a/.github/workflows/insider.yaml
+++ b/.github/workflows/insider.yaml
@@ -13,7 +13,7 @@ jobs:
   insider:
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-13, windows-latest ]
         version: [ latest ] # [ x.x.x | latest | max ]
         type: [ insider ] # [ stable | insider ]
       fail-fast: false
@@ -35,7 +35,7 @@ jobs:
           distribution: "temurin"
 
       - name: Install JBang (ubuntu, macOS)
-        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-13'
         run: |
           curl -Ls https://sh.jbang.dev | bash -s - app setup
           echo "$HOME/.jbang/bin" >> $GITHUB_PATH
@@ -91,7 +91,7 @@ jobs:
 
       - name: Store VS Code Logs (Macos)
         uses: actions/upload-artifact@v3
-        if: failure() && matrix.os == 'macos-latest'
+        if: failure() && matrix.os == 'macos-13'
         with:
           name: ${{ matrix.os }}-${{ matrix.version }}-vscode-logs
           path: ~/Library/Application Support/Code/logs/*

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,7 +15,7 @@ jobs:
   main:
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-13, windows-latest ]
         version: [ "1.82.3", max ] # [ "x.x.x" | latest | max ]
         type: [ stable ] # [ stable | insider ]
       fail-fast: false
@@ -37,7 +37,7 @@ jobs:
           distribution: "temurin"
 
       - name: Install JBang (ubuntu, macOS)
-        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-13'
         run: |
           curl -Ls https://sh.jbang.dev | bash -s - app setup
           echo "$HOME/.jbang/bin" >> $GITHUB_PATH
@@ -115,7 +115,7 @@ jobs:
 
       - name: Store VS Code Logs (Macos)
         uses: actions/upload-artifact@v3
-        if: failure() && matrix.os == 'macos-latest'
+        if: failure() && matrix.os == 'macos-13'
         with:
           name: ${{ matrix.os }}-${{ matrix.version }}-vscode-logs
           path: ~/Library/Application Support/Code/logs/*


### PR DESCRIPTION
Currently we are using "macos-latest" label which points to macOS 12 were is the default system JDK = Java 8.

It would be better to switch for some time to using label "macos-13" which brings benefits of

1. testing with newer macOS
2. default system JDK is Java 17