### PR TITLE
Use same default UI tests storage as vscode-extension-tester

### DIFF
--- a/.github/workflows/insider.yaml
+++ b/.github/workflows/insider.yaml
@@ -22,6 +22,7 @@ jobs:
     env:
       CODE_VERSION: ${{ matrix.version }}
       CODE_TYPE: ${{ matrix.type }}
+      TEST_RESOURCES: test-resources
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -24,6 +24,7 @@ jobs:
     env:
       CODE_VERSION: ${{ matrix.version }}
       CODE_TYPE: ${{ matrix.type }}
+      TEST_RESOURCES: test-resources
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/src/ui-test/variables.ts
+++ b/src/ui-test/variables.ts
@@ -14,9 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import * as os from 'os';
 import * as path from 'path';
 
-export const TEST_RESOURCES_DIR = path.resolve('.', 'test-resources');
+// Enforce same default storage setup as ExTester - see https://github.com/redhat-developer/vscode-extension-tester/wiki/Test-Setup#useful-env-variables
+export const TEST_RESOURCES_DIR = process.env.TEST_RESOURCES ? process.env.TEST_RESOURCES : `${os.tmpdir()}/test-resources`;
 export const EXTENSION_DIR = path.join(TEST_RESOURCES_DIR, 'test-extensions');
 export const WORKBENCH_DIR = path.join(TEST_RESOURCES_DIR, 'ui-workbench');
 export const RESOURCES_DIR = path.resolve('.', 'src', 'ui-test', 'resources');


### PR DESCRIPTION
Enforce same default storage setup as ExTester - see https://github.com/redhat-developer/vscode-extension-tester/wiki/Test-Setup#useful-env-variables