### PR TITLE
Use NodeJS 18.x.x for gh actions builds

### DIFF
--- a/.github/workflows/insider.yaml
+++ b/.github/workflows/insider.yaml
@@ -50,7 +50,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "18.15.x"
+          node-version: "18.x"
           cache: "npm"
 
       - name: Install global dependencies

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -52,7 +52,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "18.15.x"
+          node-version: "18.x"
           cache: "npm"
 
       - name: Install global dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
 				"mocha-jenkins-reporter": "^0.4.8",
 				"mvn-artifact-download": "^6.1.1",
 				"typescript": "^5.3.3",
-				"vscode-uitests-tooling": "^4.0.11"
+				"vscode-uitests-tooling": "^4.0.12"
 			},
 			"engines": {
 				"vscode": "^1.82.0"
@@ -971,16 +971,15 @@
 			}
 		},
 		"node_modules/@vscode/vsce": {
-			"version": "2.23.0",
-			"resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-2.23.0.tgz",
-			"integrity": "sha512-Wf9yN8feZf4XmUW/erXyKQvCL577u72AQv4AI4Cwt5o5NyE49C5mpfw3pN78BJYYG3qnSIxwRo7JPvEurkQuNA==",
+			"version": "2.24.0",
+			"resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-2.24.0.tgz",
+			"integrity": "sha512-p6CIXpH5HXDqmUkgFXvIKTjZpZxy/uDx4d/UsfhS9vQUun43KDNUbYeZocyAHgqcJlPEurgArHz9te1PPiqPyA==",
 			"dev": true,
 			"dependencies": {
 				"azure-devops-node-api": "^11.0.1",
 				"chalk": "^2.4.2",
 				"cheerio": "^1.0.0-rc.9",
 				"commander": "^6.2.1",
-				"find-yarn-workspace-root": "^2.0.0",
 				"glob": "^7.0.6",
 				"hosted-git-info": "^4.0.2",
 				"jsonc-parser": "^3.2.0",
@@ -1294,28 +1293,6 @@
 			],
 			"optional": true
 		},
-		"node_modules/big-integer": {
-			"version": "1.6.52",
-			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
-			"integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.6"
-			}
-		},
-		"node_modules/binary": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
-			"integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
-			"dev": true,
-			"dependencies": {
-				"buffers": "~0.1.1",
-				"chainsaw": "~0.1.0"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/binary-extensions": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -1351,12 +1328,6 @@
 			"engines": {
 				"node": ">= 6"
 			}
-		},
-		"node_modules/bluebird": {
-			"version": "3.4.7",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-			"integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
-			"dev": true
 		},
 		"node_modules/boolbase": {
 			"version": "1.0.0",
@@ -1447,24 +1418,6 @@
 			"resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
 			"integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==",
 			"dev": true
-		},
-		"node_modules/buffer-indexof-polyfill": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
-			"integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10"
-			}
-		},
-		"node_modules/buffers": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-			"integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.2.0"
-			}
 		},
 		"node_modules/cacheable-lookup": {
 			"version": "7.0.0",
@@ -1561,18 +1514,6 @@
 			},
 			"engines": {
 				"node": ">=4"
-			}
-		},
-		"node_modules/chainsaw": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
-			"integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
-			"dev": true,
-			"dependencies": {
-				"traverse": ">=0.3.0 <0.4"
-			},
-			"engines": {
-				"node": "*"
 			}
 		},
 		"node_modules/chalk": {
@@ -1760,9 +1701,9 @@
 			}
 		},
 		"node_modules/clipboardy/node_modules/npm-run-path": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.2.0.tgz",
-			"integrity": "sha512-W4/tgAXFqFA0iL7fk0+uQ3g7wkL8xJmx3XdK0VGb4cHW//eZTtKGvFBBoRKVTpY7n6ze4NL9ly7rgXcHufqXKg==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+			"integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
 			"dev": true,
 			"dependencies": {
 				"path-key": "^4.0.0"
@@ -2180,15 +2121,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/duplexer2": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-			"integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
-			"dev": true,
-			"dependencies": {
-				"readable-stream": "^2.0.2"
-			}
-		},
 		"node_modules/eastasianwidth": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -2541,15 +2473,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/find-yarn-workspace-root": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
-			"integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
-			"dev": true,
-			"dependencies": {
-				"micromatch": "^4.0.2"
-			}
-		},
 		"node_modules/flat": {
 			"version": "5.0.2",
 			"resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
@@ -2672,53 +2595,6 @@
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 			"dev": true
-		},
-		"node_modules/fstream": {
-			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-			"integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
-			"dev": true,
-			"dependencies": {
-				"graceful-fs": "^4.1.2",
-				"inherits": "~2.0.0",
-				"mkdirp": ">=0.5 0",
-				"rimraf": "2"
-			},
-			"engines": {
-				"node": ">=0.6"
-			}
-		},
-		"node_modules/fstream/node_modules/glob": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-			"dev": true,
-			"dependencies": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.1.1",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			},
-			"engines": {
-				"node": "*"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/fstream/node_modules/rimraf": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-			"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-			"dev": true,
-			"dependencies": {
-				"glob": "^7.1.3"
-			},
-			"bin": {
-				"rimraf": "bin.js"
-			}
 		},
 		"node_modules/function-bind": {
 			"version": "1.1.2",
@@ -3549,12 +3425,6 @@
 				"uc.micro": "^1.0.1"
 			}
 		},
-		"node_modules/listenercount": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
-			"integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
-			"dev": true
-		},
 		"node_modules/locate-path": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -4028,9 +3898,9 @@
 			"dev": true
 		},
 		"node_modules/node-abi": {
-			"version": "3.55.0",
-			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.55.0.tgz",
-			"integrity": "sha512-uPEjtyh2tFEvWYt4Jw7McOD5FPcHkcxm/tHZc5PWaDB3JYq0rGFUbgaAK+CT5pYpQddBfsZVWI08OwoRfdfbcQ==",
+			"version": "3.56.0",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.56.0.tgz",
+			"integrity": "sha512-fZjdhDOeRcaS+rcpve7XuwHBmktS1nS1gzgghwKUQQ8nTy2FdSDr6ZT8k6YhvlJeHmmQMYiT/IH9hfco5zeW2Q==",
 			"dev": true,
 			"optional": true,
 			"dependencies": {
@@ -5087,15 +4957,33 @@
 			"dev": true
 		},
 		"node_modules/tmp": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-			"integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.2.tgz",
+			"integrity": "sha512-ETcvHhaIc9J2MDEAH6N67j9bvBvu/3Gb764qaGhwtFvjtvhegqoqSpofgeyq1Sc24mW5pdyUDs9HP5j3ehkxRw==",
 			"dev": true,
 			"dependencies": {
-				"rimraf": "^3.0.0"
+				"rimraf": "^5.0.5"
 			},
 			"engines": {
-				"node": ">=8.17.0"
+				"node": ">=14"
+			}
+		},
+		"node_modules/tmp/node_modules/rimraf": {
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.5.tgz",
+			"integrity": "sha512-CqDakW+hMe/Bz202FPEymy68P+G50RfMQK+Qo5YUqc9SPipvbGjCGKd0RSKEelbsfQuw3g5NZDSrlZZAJurH1A==",
+			"dev": true,
+			"dependencies": {
+				"glob": "^10.3.7"
+			},
+			"bin": {
+				"rimraf": "dist/esm/bin.mjs"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/to-buffer": {
@@ -5120,15 +5008,6 @@
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
 			"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
-		},
-		"node_modules/traverse": {
-			"version": "0.3.9",
-			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-			"integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
-			"dev": true,
-			"engines": {
-				"node": "*"
-			}
 		},
 		"node_modules/tree-kill": {
 			"version": "1.2.2",
@@ -5292,24 +5171,6 @@
 				"node": ">= 10.0.0"
 			}
 		},
-		"node_modules/unzipper": {
-			"version": "0.10.14",
-			"resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.14.tgz",
-			"integrity": "sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==",
-			"dev": true,
-			"dependencies": {
-				"big-integer": "^1.6.17",
-				"binary": "~0.3.0",
-				"bluebird": "~3.4.1",
-				"buffer-indexof-polyfill": "~1.0.0",
-				"duplexer2": "~0.1.4",
-				"fstream": "^1.0.12",
-				"graceful-fs": "^4.2.2",
-				"listenercount": "~1.0.1",
-				"readable-stream": "~2.3.6",
-				"setimmediate": "~1.0.4"
-			}
-		},
 		"node_modules/uri-js": {
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -5346,14 +5207,14 @@
 			}
 		},
 		"node_modules/vscode-extension-tester": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/vscode-extension-tester/-/vscode-extension-tester-7.1.1.tgz",
-			"integrity": "sha512-bW7miRYXuC5QTGuAe9UB25eGeRkSS8at+PQ5gdpgJp1sCij0z23KbOnvrfu2kZmGTNTgBFr2kCXjz7wHCZ/1NQ==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/vscode-extension-tester/-/vscode-extension-tester-7.2.0.tgz",
+			"integrity": "sha512-Dqx/D/EyUMuu5aCqWKZrfNF7YB+jvqlENCYOEi41zi3d4znr/U1rarx++g5o3EARdUYPos5iBNo+MVr81/OlZQ==",
 			"dev": true,
 			"dependencies": {
 				"@types/selenium-webdriver": "^4.1.21",
 				"@types/targz": "^1.0.4",
-				"@vscode/vsce": "^2.23.0",
+				"@vscode/vsce": "^2.24.0",
 				"commander": "^12.0.0",
 				"compare-versions": "^6.1.0",
 				"fs-extra": "^11.2.0",
@@ -5365,7 +5226,6 @@
 				"sanitize-filename": "^1.6.3",
 				"selenium-webdriver": "^4.18.1",
 				"targz": "^1.0.1",
-				"unzipper": "^0.10.14",
 				"vscode-extension-tester-locators": "^3.11.0"
 			},
 			"bin": {
@@ -5387,16 +5247,16 @@
 			}
 		},
 		"node_modules/vscode-uitests-tooling": {
-			"version": "4.0.11",
-			"resolved": "https://registry.npmjs.org/vscode-uitests-tooling/-/vscode-uitests-tooling-4.0.11.tgz",
-			"integrity": "sha512-ibTkoXujAtz4z1BIHNALAz7MfJrPt11twlmlEnxlOegvCph4QOGPqssjRz+/BrsTLv2RX4EtThepagkmgymYgA==",
+			"version": "4.0.12",
+			"resolved": "https://registry.npmjs.org/vscode-uitests-tooling/-/vscode-uitests-tooling-4.0.12.tgz",
+			"integrity": "sha512-0QCkgQSR1hH9kMUIVY5n05RMrZjQpkYPQWqPyj1jZzDk1FJcjgkq97fAW9L02tDZ3vK2CV0wwOCgsW6fVqMAfA==",
 			"dev": true,
 			"dependencies": {
 				"clipboardy": "^4.0.0",
 				"fs-extra": "^11.1.1",
 				"sanitize-filename": "^1.6.3",
 				"tree-kill": "^1.2.2",
-				"vscode-extension-tester": "^7.1.1"
+				"vscode-extension-tester": "^7.2.0"
 			},
 			"peerDependencies": {
 				"mocha": ">=5.2.0"
@@ -6286,16 +6146,15 @@
 			}
 		},
 		"@vscode/vsce": {
-			"version": "2.23.0",
-			"resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-2.23.0.tgz",
-			"integrity": "sha512-Wf9yN8feZf4XmUW/erXyKQvCL577u72AQv4AI4Cwt5o5NyE49C5mpfw3pN78BJYYG3qnSIxwRo7JPvEurkQuNA==",
+			"version": "2.24.0",
+			"resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-2.24.0.tgz",
+			"integrity": "sha512-p6CIXpH5HXDqmUkgFXvIKTjZpZxy/uDx4d/UsfhS9vQUun43KDNUbYeZocyAHgqcJlPEurgArHz9te1PPiqPyA==",
 			"dev": true,
 			"requires": {
 				"azure-devops-node-api": "^11.0.1",
 				"chalk": "^2.4.2",
 				"cheerio": "^1.0.0-rc.9",
 				"commander": "^6.2.1",
-				"find-yarn-workspace-root": "^2.0.0",
 				"glob": "^7.0.6",
 				"hosted-git-info": "^4.0.2",
 				"jsonc-parser": "^3.2.0",
@@ -6525,22 +6384,6 @@
 			"dev": true,
 			"optional": true
 		},
-		"big-integer": {
-			"version": "1.6.52",
-			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
-			"integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
-			"dev": true
-		},
-		"binary": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
-			"integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
-			"dev": true,
-			"requires": {
-				"buffers": "~0.1.1",
-				"chainsaw": "~0.1.0"
-			}
-		},
 		"binary-extensions": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -6572,12 +6415,6 @@
 					}
 				}
 			}
-		},
-		"bluebird": {
-			"version": "3.4.7",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-			"integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
-			"dev": true
 		},
 		"boolbase": {
 			"version": "1.0.0",
@@ -6649,18 +6486,6 @@
 			"integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==",
 			"dev": true
 		},
-		"buffer-indexof-polyfill": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
-			"integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
-			"dev": true
-		},
-		"buffers": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-			"integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
-			"dev": true
-		},
 		"cacheable-lookup": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
@@ -6728,15 +6553,6 @@
 				"loupe": "^2.3.6",
 				"pathval": "^1.1.1",
 				"type-detect": "^4.0.8"
-			}
-		},
-		"chainsaw": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
-			"integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
-			"dev": true,
-			"requires": {
-				"traverse": ">=0.3.0 <0.4"
 			}
 		},
 		"chalk": {
@@ -6862,9 +6678,9 @@
 					"dev": true
 				},
 				"npm-run-path": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.2.0.tgz",
-					"integrity": "sha512-W4/tgAXFqFA0iL7fk0+uQ3g7wkL8xJmx3XdK0VGb4cHW//eZTtKGvFBBoRKVTpY7n6ze4NL9ly7rgXcHufqXKg==",
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+					"integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
 					"dev": true,
 					"requires": {
 						"path-key": "^4.0.0"
@@ -7151,15 +6967,6 @@
 			"resolved": "https://registry.npmjs.org/dset/-/dset-3.1.2.tgz",
 			"integrity": "sha512-g/M9sqy3oHe477Ar4voQxWtaPIFw1jTdKZuomOjhCcBx9nHUNn0pu6NopuFFrTh/TRZIKEj+76vLWFu9BNKk+Q=="
 		},
-		"duplexer2": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-			"integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
-			"dev": true,
-			"requires": {
-				"readable-stream": "^2.0.2"
-			}
-		},
 		"eastasianwidth": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -7427,15 +7234,6 @@
 				"path-exists": "^4.0.0"
 			}
 		},
-		"find-yarn-workspace-root": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
-			"integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
-			"dev": true,
-			"requires": {
-				"micromatch": "^4.0.2"
-			}
-		},
 		"flat": {
 			"version": "5.0.2",
 			"resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
@@ -7519,43 +7317,6 @@
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 			"dev": true
-		},
-		"fstream": {
-			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-			"integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
-			"dev": true,
-			"requires": {
-				"graceful-fs": "^4.1.2",
-				"inherits": "~2.0.0",
-				"mkdirp": ">=0.5 0",
-				"rimraf": "2"
-			},
-			"dependencies": {
-				"glob": {
-					"version": "7.2.3",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-					"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-					"dev": true,
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.1.1",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
-				"rimraf": {
-					"version": "2.7.1",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-					"dev": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				}
-			}
 		},
 		"function-bind": {
 			"version": "1.1.2",
@@ -8148,12 +7909,6 @@
 				"uc.micro": "^1.0.1"
 			}
 		},
-		"listenercount": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
-			"integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
-			"dev": true
-		},
 		"locate-path": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -8513,9 +8268,9 @@
 			"dev": true
 		},
 		"node-abi": {
-			"version": "3.55.0",
-			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.55.0.tgz",
-			"integrity": "sha512-uPEjtyh2tFEvWYt4Jw7McOD5FPcHkcxm/tHZc5PWaDB3JYq0rGFUbgaAK+CT5pYpQddBfsZVWI08OwoRfdfbcQ==",
+			"version": "3.56.0",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.56.0.tgz",
+			"integrity": "sha512-fZjdhDOeRcaS+rcpve7XuwHBmktS1nS1gzgghwKUQQ8nTy2FdSDr6ZT8k6YhvlJeHmmQMYiT/IH9hfco5zeW2Q==",
 			"dev": true,
 			"optional": true,
 			"requires": {
@@ -9280,12 +9035,23 @@
 			"dev": true
 		},
 		"tmp": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-			"integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.2.tgz",
+			"integrity": "sha512-ETcvHhaIc9J2MDEAH6N67j9bvBvu/3Gb764qaGhwtFvjtvhegqoqSpofgeyq1Sc24mW5pdyUDs9HP5j3ehkxRw==",
 			"dev": true,
 			"requires": {
-				"rimraf": "^3.0.0"
+				"rimraf": "^5.0.5"
+			},
+			"dependencies": {
+				"rimraf": {
+					"version": "5.0.5",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.5.tgz",
+					"integrity": "sha512-CqDakW+hMe/Bz202FPEymy68P+G50RfMQK+Qo5YUqc9SPipvbGjCGKd0RSKEelbsfQuw3g5NZDSrlZZAJurH1A==",
+					"dev": true,
+					"requires": {
+						"glob": "^10.3.7"
+					}
+				}
 			}
 		},
 		"to-buffer": {
@@ -9307,12 +9073,6 @@
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
 			"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
-		},
-		"traverse": {
-			"version": "0.3.9",
-			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-			"integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
-			"dev": true
 		},
 		"tree-kill": {
 			"version": "1.2.2",
@@ -9420,24 +9180,6 @@
 			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
 			"dev": true
 		},
-		"unzipper": {
-			"version": "0.10.14",
-			"resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.14.tgz",
-			"integrity": "sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==",
-			"dev": true,
-			"requires": {
-				"big-integer": "^1.6.17",
-				"binary": "~0.3.0",
-				"bluebird": "~3.4.1",
-				"buffer-indexof-polyfill": "~1.0.0",
-				"duplexer2": "~0.1.4",
-				"fstream": "^1.0.12",
-				"graceful-fs": "^4.2.2",
-				"listenercount": "~1.0.1",
-				"readable-stream": "~2.3.6",
-				"setimmediate": "~1.0.4"
-			}
-		},
 		"uri-js": {
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -9471,14 +9213,14 @@
 			"integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
 		},
 		"vscode-extension-tester": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/vscode-extension-tester/-/vscode-extension-tester-7.1.1.tgz",
-			"integrity": "sha512-bW7miRYXuC5QTGuAe9UB25eGeRkSS8at+PQ5gdpgJp1sCij0z23KbOnvrfu2kZmGTNTgBFr2kCXjz7wHCZ/1NQ==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/vscode-extension-tester/-/vscode-extension-tester-7.2.0.tgz",
+			"integrity": "sha512-Dqx/D/EyUMuu5aCqWKZrfNF7YB+jvqlENCYOEi41zi3d4znr/U1rarx++g5o3EARdUYPos5iBNo+MVr81/OlZQ==",
 			"dev": true,
 			"requires": {
 				"@types/selenium-webdriver": "^4.1.21",
 				"@types/targz": "^1.0.4",
-				"@vscode/vsce": "^2.23.0",
+				"@vscode/vsce": "^2.24.0",
 				"commander": "^12.0.0",
 				"compare-versions": "^6.1.0",
 				"fs-extra": "^11.2.0",
@@ -9490,7 +9232,6 @@
 				"sanitize-filename": "^1.6.3",
 				"selenium-webdriver": "^4.18.1",
 				"targz": "^1.0.1",
-				"unzipper": "^0.10.14",
 				"vscode-extension-tester-locators": "^3.11.0"
 			}
 		},
@@ -9502,16 +9243,16 @@
 			"requires": {}
 		},
 		"vscode-uitests-tooling": {
-			"version": "4.0.11",
-			"resolved": "https://registry.npmjs.org/vscode-uitests-tooling/-/vscode-uitests-tooling-4.0.11.tgz",
-			"integrity": "sha512-ibTkoXujAtz4z1BIHNALAz7MfJrPt11twlmlEnxlOegvCph4QOGPqssjRz+/BrsTLv2RX4EtThepagkmgymYgA==",
+			"version": "4.0.12",
+			"resolved": "https://registry.npmjs.org/vscode-uitests-tooling/-/vscode-uitests-tooling-4.0.12.tgz",
+			"integrity": "sha512-0QCkgQSR1hH9kMUIVY5n05RMrZjQpkYPQWqPyj1jZzDk1FJcjgkq97fAW9L02tDZ3vK2CV0wwOCgsW6fVqMAfA==",
 			"dev": true,
 			"requires": {
 				"clipboardy": "^4.0.0",
 				"fs-extra": "^11.1.1",
 				"sanitize-filename": "^1.6.3",
 				"tree-kill": "^1.2.2",
-				"vscode-extension-tester": "^7.1.1"
+				"vscode-extension-tester": "^7.2.0"
 			}
 		},
 		"webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -263,7 +263,7 @@
 		"mocha-jenkins-reporter": "^0.4.8",
 		"mvn-artifact-download": "^6.1.1",
 		"typescript": "^5.3.3",
-		"vscode-uitests-tooling": "^4.0.11"
+		"vscode-uitests-tooling": "^4.0.12"
 	},
 	"dependencies": {
 		"@redhat-developer/vscode-redhat-telemetry": "^0.7.1",


### PR DESCRIPTION
vscode-uitests-tooling v4.0.12 is shipping ExTester v7.2.0 which is enabling running tests with NodeJS 18+