### PR TITLE
Increase minimal VS Code version to test with

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-13, windows-latest ]
-        version: [ "1.82.3", max ] # [ "x.x.x" | latest | max ]
+        version: [ "1.86.2", max ] # [ "x.x.x" | latest | max ]
         type: [ stable ] # [ stable | insider ]
       fail-fast: false
     timeout-minutes: 25


### PR DESCRIPTION
With new feature of preference, some tests are failing with 1.82.3 on CI. Updating to more recent version as we want to ensure only 2 versions at least and only best effort for more