### PR TITLE
Bump vscode-uitests-tooling from 4.1.0 to 4.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
 				"mocha-jenkins-reporter": "^0.4.8",
 				"mvn-artifact-download": "^6.1.1",
 				"typescript": "^5.4.5",
-				"vscode-uitests-tooling": "^4.1.0"
+				"vscode-uitests-tooling": "^4.1.1"
 			},
 			"engines": {
 				"vscode": "^1.82.0"
@@ -43,6 +43,261 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@azure/abort-controller": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
+			"integrity": "sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==",
+			"dev": true,
+			"dependencies": {
+				"tslib": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/@azure/core-auth": {
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.7.2.tgz",
+			"integrity": "sha512-Igm/S3fDYmnMq1uKS38Ae1/m37B3zigdlZw+kocwEhh5GjyKjPrXKO2J6rzpC1wAxrNil/jX9BJRqBshyjnF3g==",
+			"dev": true,
+			"dependencies": {
+				"@azure/abort-controller": "^2.0.0",
+				"@azure/core-util": "^1.1.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@azure/core-auth/node_modules/@azure/abort-controller": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+			"integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+			"dev": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@azure/core-client": {
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.9.2.tgz",
+			"integrity": "sha512-kRdry/rav3fUKHl/aDLd/pDLcB+4pOFwPPTVEExuMyaI5r+JBbMWqRbCY1pn5BniDaU3lRxO9eaQ1AmSMehl/w==",
+			"dev": true,
+			"dependencies": {
+				"@azure/abort-controller": "^2.0.0",
+				"@azure/core-auth": "^1.4.0",
+				"@azure/core-rest-pipeline": "^1.9.1",
+				"@azure/core-tracing": "^1.0.0",
+				"@azure/core-util": "^1.6.1",
+				"@azure/logger": "^1.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@azure/core-client/node_modules/@azure/abort-controller": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+			"integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+			"dev": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@azure/core-rest-pipeline": {
+			"version": "1.15.2",
+			"resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.15.2.tgz",
+			"integrity": "sha512-BmWfpjc/QXc2ipHOh6LbUzp3ONCaa6xzIssTU0DwH9bbYNXJlGUL6tujx5TrbVd/QQknmS+vlQJGrCq2oL1gZA==",
+			"dev": true,
+			"dependencies": {
+				"@azure/abort-controller": "^2.0.0",
+				"@azure/core-auth": "^1.4.0",
+				"@azure/core-tracing": "^1.0.1",
+				"@azure/core-util": "^1.3.0",
+				"@azure/logger": "^1.0.0",
+				"http-proxy-agent": "^7.0.0",
+				"https-proxy-agent": "^7.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@azure/core-rest-pipeline/node_modules/@azure/abort-controller": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+			"integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+			"dev": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@azure/core-rest-pipeline/node_modules/agent-base": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+			"integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+			"dev": true,
+			"dependencies": {
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/@azure/core-rest-pipeline/node_modules/http-proxy-agent": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+			"dev": true,
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/@azure/core-rest-pipeline/node_modules/https-proxy-agent": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
+			"integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+			"dev": true,
+			"dependencies": {
+				"agent-base": "^7.0.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/@azure/core-tracing": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.1.2.tgz",
+			"integrity": "sha512-dawW9ifvWAWmUm9/h+/UQ2jrdvjCJ7VJEuCJ6XVNudzcOwm53BFZH4Q845vjfgoUAM8ZxokvVNxNxAITc502YA==",
+			"dev": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@azure/core-util": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.9.0.tgz",
+			"integrity": "sha512-AfalUQ1ZppaKuxPPMsFEUdX6GZPB3d9paR9d/TTL7Ow2De8cJaC7ibi7kWVlFAVPCYo31OcnGymc0R89DX8Oaw==",
+			"dev": true,
+			"dependencies": {
+				"@azure/abort-controller": "^2.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@azure/core-util/node_modules/@azure/abort-controller": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+			"integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+			"dev": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@azure/identity": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.1.0.tgz",
+			"integrity": "sha512-BhYkF8Xr2gXjyDxocm0pc9RI5J5a1jw8iW0dw6Bx95OGdYbuMyFZrrwNw4eYSqQ2BB6FZOqpJP3vjsAqRcvDhw==",
+			"dev": true,
+			"dependencies": {
+				"@azure/abort-controller": "^1.0.0",
+				"@azure/core-auth": "^1.5.0",
+				"@azure/core-client": "^1.4.0",
+				"@azure/core-rest-pipeline": "^1.1.0",
+				"@azure/core-tracing": "^1.0.0",
+				"@azure/core-util": "^1.3.0",
+				"@azure/logger": "^1.0.0",
+				"@azure/msal-browser": "^3.11.1",
+				"@azure/msal-node": "^2.6.6",
+				"events": "^3.0.0",
+				"jws": "^4.0.0",
+				"open": "^8.0.0",
+				"stoppable": "^1.1.0",
+				"tslib": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@azure/logger": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.1.2.tgz",
+			"integrity": "sha512-l170uE7bsKpIU6B/giRc9i4NI0Mj+tANMMMxf7Zi/5cKzEqPayP7+X1WPrG7e+91JgY8N+7K7nF2WOi7iVhXvg==",
+			"dev": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@azure/msal-browser": {
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-3.13.0.tgz",
+			"integrity": "sha512-fD906nmJei3yE7la6DZTdUtXKvpwzJURkfsiz9747Icv4pit77cegSm6prJTKLQ1fw4iiZzrrWwxnhMLrTf5gQ==",
+			"dev": true,
+			"dependencies": {
+				"@azure/msal-common": "14.9.0"
+			},
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/@azure/msal-common": {
+			"version": "14.9.0",
+			"resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.9.0.tgz",
+			"integrity": "sha512-yzBPRlWPnTBeixxLNI3BBIgF5/bHpbhoRVuuDBnYjCyWRavaPUsKAHUDYLqpGkBLDciA6TCc6GOxN4/S3WiSxg==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/@azure/msal-node": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-2.7.0.tgz",
+			"integrity": "sha512-wXD8LkUvHICeSWZydqg6o8Yvv+grlBEcmLGu+QEI4FcwFendbTEZrlSygnAXXSOCVaGAirWLchca35qrgpO6Jw==",
+			"dev": true,
+			"dependencies": {
+				"@azure/msal-common": "14.9.0",
+				"jsonwebtoken": "^9.0.0",
+				"uuid": "^8.3.0"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@azure/msal-node/node_modules/uuid": {
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+			"dev": true,
+			"bin": {
+				"uuid": "dist/bin/uuid"
 			}
 		},
 		"node_modules/@eslint-community/eslint-utils": {
@@ -294,6 +549,32 @@
 				"node": ">=14"
 			}
 		},
+		"node_modules/@redhat-developer/locators": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@redhat-developer/locators/-/locators-1.1.0.tgz",
+			"integrity": "sha512-sSSyA1Le5ju9kvD2uY8AUKZk3iJ/ocL6KpJmBMnhecYcH96cATw9mow/5OkDEnwWihefcieerlsVRGHIQlhh0Q==",
+			"dev": true,
+			"peerDependencies": {
+				"@redhat-developer/page-objects": ">=1.0.0",
+				"selenium-webdriver": ">=4.6.1"
+			}
+		},
+		"node_modules/@redhat-developer/page-objects": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@redhat-developer/page-objects/-/page-objects-1.1.0.tgz",
+			"integrity": "sha512-h+WDFrTFcvJJq33vhakzjlFgE2tM7K0nCwonDgDuGUoW9ukerb+M/dM7m3qEGwW5T+ugz240fGElAn4jsEHBZg==",
+			"dev": true,
+			"dependencies": {
+				"clipboardy": "^4.0.0",
+				"clone-deep": "^4.0.1",
+				"compare-versions": "^6.1.0",
+				"fs-extra": "^11.2.0"
+			},
+			"peerDependencies": {
+				"selenium-webdriver": ">=4.6.1",
+				"typescript": ">=4.6.2"
+			}
+		},
 		"node_modules/@redhat-developer/vscode-redhat-telemetry": {
 			"version": "0.7.1",
 			"resolved": "https://registry.npmjs.org/@redhat-developer/vscode-redhat-telemetry/-/vscode-redhat-telemetry-0.7.1.tgz",
@@ -320,11 +601,6 @@
 				"tslib": "^2.4.1"
 			}
 		},
-		"node_modules/@segment/analytics-core/node_modules/tslib": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-			"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-		},
 		"node_modules/@segment/analytics-node": {
 			"version": "0.0.1-beta.17",
 			"resolved": "https://registry.npmjs.org/@segment/analytics-node/-/analytics-node-0.0.1-beta.17.tgz",
@@ -339,18 +615,13 @@
 				"node": ">=14"
 			}
 		},
-		"node_modules/@segment/analytics-node/node_modules/tslib": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-			"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-		},
 		"node_modules/@sindresorhus/is": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-6.2.0.tgz",
-			"integrity": "sha512-yM/IGPkVnYGblhDosFBwq0ZGdnVSBkNV4onUtipGMOjZd4kB6GAu3ys91aftSbyMHh6A2GPdt+KDI5NoWP63MQ==",
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.6.0.tgz",
+			"integrity": "sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==",
 			"dev": true,
 			"engines": {
-				"node": ">=16"
+				"node": ">=14.16"
 			},
 			"funding": {
 				"url": "https://github.com/sindresorhus/is?sponsor=1"
@@ -943,11 +1214,12 @@
 			}
 		},
 		"node_modules/@vscode/vsce": {
-			"version": "2.25.0",
-			"resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-2.25.0.tgz",
-			"integrity": "sha512-VXMCGUaP6wKBadA7vFQdsksxkBAMoh4ecZgXBwauZMASAgnwYesHyLnqIyWYeRwjy2uEpitHvz/1w5ENnR30pg==",
+			"version": "2.26.0",
+			"resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-2.26.0.tgz",
+			"integrity": "sha512-v54ltgMzUG8lGY0kAgaOlry57xse1RlWzes9FotfGEx+Fr05KeR8rZicQzEMDmi9QnOgVWHuiEq+xA2HWkAz+Q==",
 			"dev": true,
 			"dependencies": {
+				"@azure/identity": "^4.1.0",
 				"azure-devops-node-api": "^12.5.0",
 				"chalk": "^2.4.2",
 				"cheerio": "^1.0.0-rc.9",
@@ -1386,6 +1658,12 @@
 			"engines": {
 				"node": "*"
 			}
+		},
+		"node_modules/buffer-equal-constant-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+			"dev": true
 		},
 		"node_modules/buffer-fill": {
 			"version": "1.0.0",
@@ -1990,6 +2268,15 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/define-lazy-prop": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+			"integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -2109,6 +2396,15 @@
 			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
 			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
 			"dev": true
+		},
+		"node_modules/ecdsa-sig-formatter": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+			"dev": true,
+			"dependencies": {
+				"safe-buffer": "^5.0.1"
+			}
 		},
 		"node_modules/emoji-regex": {
 			"version": "8.0.0",
@@ -2332,6 +2628,15 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/events": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.8.x"
+			}
+		},
 		"node_modules/execa": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
@@ -2545,12 +2850,12 @@
 			}
 		},
 		"node_modules/form-data-encoder": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-4.0.2.tgz",
-			"integrity": "sha512-KQVhvhK8ZkWzxKxOr56CPulAhH3dobtuQ4+hNQ+HekH/Wp5gSOafqRAeTphQUJAIk0GBvHZgJ2ZGRWd5kphMuw==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz",
+			"integrity": "sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==",
 			"dev": true,
 			"engines": {
-				"node": ">= 18"
+				"node": ">= 14.17"
 			}
 		},
 		"node_modules/fs-constants": {
@@ -2760,37 +3065,37 @@
 			}
 		},
 		"node_modules/got": {
-			"version": "14.2.1",
-			"resolved": "https://registry.npmjs.org/got/-/got-14.2.1.tgz",
-			"integrity": "sha512-KOaPMremmsvx6l9BLC04LYE6ZFW4x7e4HkTe3LwBmtuYYQwpeS4XKqzhubTIkaQ1Nr+eXxeori0zuwupXMovBQ==",
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/got/-/got-13.0.0.tgz",
+			"integrity": "sha512-XfBk1CxOOScDcMr9O1yKkNaQyy865NbYs+F7dr4H0LZMVgCj2Le59k6PqbNHoL5ToeaEQUYh6c6yMfVcc6SJxA==",
 			"dev": true,
 			"dependencies": {
-				"@sindresorhus/is": "^6.1.0",
+				"@sindresorhus/is": "^5.2.0",
 				"@szmarczak/http-timer": "^5.0.1",
 				"cacheable-lookup": "^7.0.0",
-				"cacheable-request": "^10.2.14",
+				"cacheable-request": "^10.2.8",
 				"decompress-response": "^6.0.0",
-				"form-data-encoder": "^4.0.2",
-				"get-stream": "^8.0.1",
-				"http2-wrapper": "^2.2.1",
+				"form-data-encoder": "^2.1.2",
+				"get-stream": "^6.0.1",
+				"http2-wrapper": "^2.1.10",
 				"lowercase-keys": "^3.0.0",
-				"p-cancelable": "^4.0.1",
+				"p-cancelable": "^3.0.0",
 				"responselike": "^3.0.0"
 			},
 			"engines": {
-				"node": ">=20"
+				"node": ">=16"
 			},
 			"funding": {
 				"url": "https://github.com/sindresorhus/got?sponsor=1"
 			}
 		},
 		"node_modules/got/node_modules/get-stream": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
-			"integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+			"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
 			"dev": true,
 			"engines": {
-				"node": ">=16"
+				"node": ">=10"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -3315,6 +3620,49 @@
 				"graceful-fs": "^4.1.6"
 			}
 		},
+		"node_modules/jsonwebtoken": {
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+			"integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+			"dev": true,
+			"dependencies": {
+				"jws": "^3.2.2",
+				"lodash.includes": "^4.3.0",
+				"lodash.isboolean": "^3.0.3",
+				"lodash.isinteger": "^4.0.4",
+				"lodash.isnumber": "^3.0.3",
+				"lodash.isplainobject": "^4.0.6",
+				"lodash.isstring": "^4.0.1",
+				"lodash.once": "^4.0.0",
+				"ms": "^2.1.1",
+				"semver": "^7.5.4"
+			},
+			"engines": {
+				"node": ">=12",
+				"npm": ">=6"
+			}
+		},
+		"node_modules/jsonwebtoken/node_modules/jwa": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+			"integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+			"dev": true,
+			"dependencies": {
+				"buffer-equal-constant-time": "1.0.1",
+				"ecdsa-sig-formatter": "1.0.11",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/jsonwebtoken/node_modules/jws": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+			"integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+			"dev": true,
+			"dependencies": {
+				"jwa": "^1.4.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
 		"node_modules/jszip": {
 			"version": "3.10.1",
 			"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
@@ -3325,6 +3673,27 @@
 				"pako": "~1.0.2",
 				"readable-stream": "~2.3.6",
 				"setimmediate": "^1.0.5"
+			}
+		},
+		"node_modules/jwa": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+			"integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+			"dev": true,
+			"dependencies": {
+				"buffer-equal-constant-time": "1.0.1",
+				"ecdsa-sig-formatter": "1.0.11",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/jws": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+			"integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+			"dev": true,
+			"dependencies": {
+				"jwa": "^2.0.0",
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"node_modules/keytar": {
@@ -3423,10 +3792,52 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/lodash.includes": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+			"integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+			"dev": true
+		},
+		"node_modules/lodash.isboolean": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+			"integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+			"dev": true
+		},
+		"node_modules/lodash.isinteger": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+			"integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+			"dev": true
+		},
+		"node_modules/lodash.isnumber": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+			"integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+			"dev": true
+		},
+		"node_modules/lodash.isplainobject": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+			"dev": true
+		},
+		"node_modules/lodash.isstring": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+			"integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+			"dev": true
+		},
 		"node_modules/lodash.merge": {
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+			"dev": true
+		},
+		"node_modules/lodash.once": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+			"integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
 			"dev": true
 		},
 		"node_modules/log-symbols": {
@@ -3791,36 +4202,6 @@
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
-		"node_modules/monaco-page-objects": {
-			"version": "3.14.1",
-			"resolved": "https://registry.npmjs.org/monaco-page-objects/-/monaco-page-objects-3.14.1.tgz",
-			"integrity": "sha512-+inJ9rwxYraQFCA+YpjyYcoxmNHcEsxPH7bPhmeaZ09eRh0o3RQqFRZDkibFOraDpKiC5miqEDYR9pJx+hau4Q==",
-			"deprecated": "Deprecated - This package was replaced by @redhat-developer/page-objects",
-			"dev": true,
-			"dependencies": {
-				"clipboardy": "^4.0.0",
-				"clone-deep": "^4.0.1",
-				"compare-versions": "^6.1.0",
-				"fs-extra": "^11.2.0",
-				"type-fest": "^4.14.0"
-			},
-			"peerDependencies": {
-				"selenium-webdriver": ">=4.6.1",
-				"typescript": ">=4.6.2"
-			}
-		},
-		"node_modules/monaco-page-objects/node_modules/type-fest": {
-			"version": "4.15.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.15.0.tgz",
-			"integrity": "sha512-tB9lu0pQpX5KJq54g+oHOLumOx+pMep4RaM6liXh2PKmVRFF+/vAtUP0ZaJ0kOySfVNjF6doBWPHhBhISKdlIA==",
-			"dev": true,
-			"engines": {
-				"node": ">=16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -3894,9 +4275,9 @@
 			"dev": true
 		},
 		"node_modules/node-abi": {
-			"version": "3.58.0",
-			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.58.0.tgz",
-			"integrity": "sha512-pXY1jnGf5T7b8UNzWzIqf0EkX4bx/w8N2AvwlGnk2SYYA/kzDVPaH0Dh0UG4EwxBB5eKOIZKPr8VAHSHL1DPGg==",
+			"version": "3.62.0",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.62.0.tgz",
+			"integrity": "sha512-CPMcGa+y33xuL1E0TcNIu4YyaZCxnnvkVaEXrsosR3FxN+fV8xvb7Mzpb7IgKler10qeMkE6+Dp8qJhpzdq35g==",
 			"dev": true,
 			"optional": true,
 			"dependencies": {
@@ -4015,6 +4396,50 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/open": {
+			"version": "8.4.2",
+			"resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+			"integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+			"dev": true,
+			"dependencies": {
+				"define-lazy-prop": "^2.0.0",
+				"is-docker": "^2.1.1",
+				"is-wsl": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/open/node_modules/is-docker": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+			"integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+			"dev": true,
+			"bin": {
+				"is-docker": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/open/node_modules/is-wsl": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+			"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+			"dev": true,
+			"dependencies": {
+				"is-docker": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/optionator": {
 			"version": "0.9.3",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
@@ -4049,12 +4474,12 @@
 			}
 		},
 		"node_modules/p-cancelable": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-4.0.1.tgz",
-			"integrity": "sha512-wBowNApzd45EIKdO1LaU+LrMBwAcjfPaYtVzV3lmfM3gf8Z4CHZsiIqlM8TZZ8okYvh5A1cP6gTfCRQtwUpaUg==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
+			"integrity": "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==",
 			"dev": true,
 			"engines": {
-				"node": ">=14.16"
+				"node": ">=12.20"
 			}
 		},
 		"node_modules/p-defer": {
@@ -4735,6 +5160,16 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/stoppable": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
+			"integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
+			"dev": true,
+			"engines": {
+				"node": ">=4",
+				"npm": ">=6"
+			}
+		},
 		"node_modules/string_decoder": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -5014,6 +5449,11 @@
 				"typescript": ">=4.2.0"
 			}
 		},
+		"node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
 		"node_modules/tunnel": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
@@ -5168,29 +5608,25 @@
 			}
 		},
 		"node_modules/vscode-extension-tester": {
-			"version": "7.3.2",
-			"resolved": "https://registry.npmjs.org/vscode-extension-tester/-/vscode-extension-tester-7.3.2.tgz",
-			"integrity": "sha512-qjswvU00k+n9yeC4cJupm2067cZAm+cxMVmbcssZp4lI6OMbbUDP4s2c9i1sODwCv8MTzzzQw+z6+4xagUeQmA==",
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/vscode-extension-tester/-/vscode-extension-tester-8.1.0.tgz",
+			"integrity": "sha512-gXyGi4D+ZqemAvt7IegFUBxVLQH1ftTRiMKqlwH1BBi+x1yhPXXuIVo6TSWUlyGMznbpFV5DUK3GEAfc13nSsg==",
 			"dev": true,
-			"workspaces": [
-				"page-objects",
-				"locators"
-			],
 			"dependencies": {
+				"@redhat-developer/locators": "^1.1.0",
+				"@redhat-developer/page-objects": "^1.1.0",
 				"@types/selenium-webdriver": "^4.1.22",
-				"@vscode/vsce": "^2.24.0",
+				"@vscode/vsce": "^2.26.0",
 				"commander": "^12.0.0",
 				"compare-versions": "^6.1.0",
 				"fs-extra": "^11.2.0",
-				"glob": "^10.3.10",
-				"got": "^14.2.1",
+				"glob": "^10.3.12",
+				"got": "^13.0.0",
 				"hpagent": "^1.2.0",
 				"js-yaml": "^4.1.0",
-				"monaco-page-objects": "^3.14.1",
 				"sanitize-filename": "^1.6.3",
-				"selenium-webdriver": "^4.18.1",
-				"targz": "^1.0.1",
-				"vscode-extension-tester-locators": "^3.12.2"
+				"selenium-webdriver": "^4.19.0",
+				"targz": "^1.0.1"
 			},
 			"bin": {
 				"extest": "out/cli.js"
@@ -5200,28 +5636,17 @@
 				"typescript": ">=4.6.2"
 			}
 		},
-		"node_modules/vscode-extension-tester-locators": {
-			"version": "3.12.2",
-			"resolved": "https://registry.npmjs.org/vscode-extension-tester-locators/-/vscode-extension-tester-locators-3.12.2.tgz",
-			"integrity": "sha512-RMN+AMGhK4dSPauJoAQ1Os4Kju9br7HvcwflkgWn7M81HEo2lt/wEsLKtEm0igSc3u4iKDH3R1D/kqbxW8A/UQ==",
-			"deprecated": "Deprecated - This package was replaced by @redhat-developer/locators",
-			"dev": true,
-			"peerDependencies": {
-				"monaco-page-objects": "^3.14.1",
-				"selenium-webdriver": ">=4.6.1"
-			}
-		},
 		"node_modules/vscode-uitests-tooling": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/vscode-uitests-tooling/-/vscode-uitests-tooling-4.1.0.tgz",
-			"integrity": "sha512-pcRrCAmFtTnWq9qyP6zcx2lTuXLzHSQ8tvO814WzXbSLCFqAw7gKq+wsaFLYvYVeZ0XHKB7rQ3fDU7PNGbAxUw==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/vscode-uitests-tooling/-/vscode-uitests-tooling-4.1.1.tgz",
+			"integrity": "sha512-E3ZDmuBeSMo64+0Di+Us6IN5YEu6tciVsLLd3XMBIOmhW/hh+RKKpyCKrczPx6zfKESl5eLbnJ7CTFKtu4URRw==",
 			"dev": true,
 			"dependencies": {
 				"clipboardy": "^4.0.0",
 				"fs-extra": "^11.2.0",
 				"sanitize-filename": "^1.6.3",
 				"tree-kill": "^1.2.2",
-				"vscode-extension-tester": "^7.3.2"
+				"vscode-extension-tester": "^8.1.0"
 			},
 			"peerDependencies": {
 				"mocha": ">=5.2.0",
@@ -5456,6 +5881,214 @@
 			"integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
 			"dev": true
 		},
+		"@azure/abort-controller": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
+			"integrity": "sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==",
+			"dev": true,
+			"requires": {
+				"tslib": "^2.2.0"
+			}
+		},
+		"@azure/core-auth": {
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.7.2.tgz",
+			"integrity": "sha512-Igm/S3fDYmnMq1uKS38Ae1/m37B3zigdlZw+kocwEhh5GjyKjPrXKO2J6rzpC1wAxrNil/jX9BJRqBshyjnF3g==",
+			"dev": true,
+			"requires": {
+				"@azure/abort-controller": "^2.0.0",
+				"@azure/core-util": "^1.1.0",
+				"tslib": "^2.6.2"
+			},
+			"dependencies": {
+				"@azure/abort-controller": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+					"integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+					"dev": true,
+					"requires": {
+						"tslib": "^2.6.2"
+					}
+				}
+			}
+		},
+		"@azure/core-client": {
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.9.2.tgz",
+			"integrity": "sha512-kRdry/rav3fUKHl/aDLd/pDLcB+4pOFwPPTVEExuMyaI5r+JBbMWqRbCY1pn5BniDaU3lRxO9eaQ1AmSMehl/w==",
+			"dev": true,
+			"requires": {
+				"@azure/abort-controller": "^2.0.0",
+				"@azure/core-auth": "^1.4.0",
+				"@azure/core-rest-pipeline": "^1.9.1",
+				"@azure/core-tracing": "^1.0.0",
+				"@azure/core-util": "^1.6.1",
+				"@azure/logger": "^1.0.0",
+				"tslib": "^2.6.2"
+			},
+			"dependencies": {
+				"@azure/abort-controller": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+					"integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+					"dev": true,
+					"requires": {
+						"tslib": "^2.6.2"
+					}
+				}
+			}
+		},
+		"@azure/core-rest-pipeline": {
+			"version": "1.15.2",
+			"resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.15.2.tgz",
+			"integrity": "sha512-BmWfpjc/QXc2ipHOh6LbUzp3ONCaa6xzIssTU0DwH9bbYNXJlGUL6tujx5TrbVd/QQknmS+vlQJGrCq2oL1gZA==",
+			"dev": true,
+			"requires": {
+				"@azure/abort-controller": "^2.0.0",
+				"@azure/core-auth": "^1.4.0",
+				"@azure/core-tracing": "^1.0.1",
+				"@azure/core-util": "^1.3.0",
+				"@azure/logger": "^1.0.0",
+				"http-proxy-agent": "^7.0.0",
+				"https-proxy-agent": "^7.0.0",
+				"tslib": "^2.6.2"
+			},
+			"dependencies": {
+				"@azure/abort-controller": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+					"integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+					"dev": true,
+					"requires": {
+						"tslib": "^2.6.2"
+					}
+				},
+				"agent-base": {
+					"version": "7.1.1",
+					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+					"integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+					"dev": true,
+					"requires": {
+						"debug": "^4.3.4"
+					}
+				},
+				"http-proxy-agent": {
+					"version": "7.0.2",
+					"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+					"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+					"dev": true,
+					"requires": {
+						"agent-base": "^7.1.0",
+						"debug": "^4.3.4"
+					}
+				},
+				"https-proxy-agent": {
+					"version": "7.0.4",
+					"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
+					"integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+					"dev": true,
+					"requires": {
+						"agent-base": "^7.0.2",
+						"debug": "4"
+					}
+				}
+			}
+		},
+		"@azure/core-tracing": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.1.2.tgz",
+			"integrity": "sha512-dawW9ifvWAWmUm9/h+/UQ2jrdvjCJ7VJEuCJ6XVNudzcOwm53BFZH4Q845vjfgoUAM8ZxokvVNxNxAITc502YA==",
+			"dev": true,
+			"requires": {
+				"tslib": "^2.6.2"
+			}
+		},
+		"@azure/core-util": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.9.0.tgz",
+			"integrity": "sha512-AfalUQ1ZppaKuxPPMsFEUdX6GZPB3d9paR9d/TTL7Ow2De8cJaC7ibi7kWVlFAVPCYo31OcnGymc0R89DX8Oaw==",
+			"dev": true,
+			"requires": {
+				"@azure/abort-controller": "^2.0.0",
+				"tslib": "^2.6.2"
+			},
+			"dependencies": {
+				"@azure/abort-controller": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+					"integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+					"dev": true,
+					"requires": {
+						"tslib": "^2.6.2"
+					}
+				}
+			}
+		},
+		"@azure/identity": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.1.0.tgz",
+			"integrity": "sha512-BhYkF8Xr2gXjyDxocm0pc9RI5J5a1jw8iW0dw6Bx95OGdYbuMyFZrrwNw4eYSqQ2BB6FZOqpJP3vjsAqRcvDhw==",
+			"dev": true,
+			"requires": {
+				"@azure/abort-controller": "^1.0.0",
+				"@azure/core-auth": "^1.5.0",
+				"@azure/core-client": "^1.4.0",
+				"@azure/core-rest-pipeline": "^1.1.0",
+				"@azure/core-tracing": "^1.0.0",
+				"@azure/core-util": "^1.3.0",
+				"@azure/logger": "^1.0.0",
+				"@azure/msal-browser": "^3.11.1",
+				"@azure/msal-node": "^2.6.6",
+				"events": "^3.0.0",
+				"jws": "^4.0.0",
+				"open": "^8.0.0",
+				"stoppable": "^1.1.0",
+				"tslib": "^2.2.0"
+			}
+		},
+		"@azure/logger": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.1.2.tgz",
+			"integrity": "sha512-l170uE7bsKpIU6B/giRc9i4NI0Mj+tANMMMxf7Zi/5cKzEqPayP7+X1WPrG7e+91JgY8N+7K7nF2WOi7iVhXvg==",
+			"dev": true,
+			"requires": {
+				"tslib": "^2.6.2"
+			}
+		},
+		"@azure/msal-browser": {
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-3.13.0.tgz",
+			"integrity": "sha512-fD906nmJei3yE7la6DZTdUtXKvpwzJURkfsiz9747Icv4pit77cegSm6prJTKLQ1fw4iiZzrrWwxnhMLrTf5gQ==",
+			"dev": true,
+			"requires": {
+				"@azure/msal-common": "14.9.0"
+			}
+		},
+		"@azure/msal-common": {
+			"version": "14.9.0",
+			"resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.9.0.tgz",
+			"integrity": "sha512-yzBPRlWPnTBeixxLNI3BBIgF5/bHpbhoRVuuDBnYjCyWRavaPUsKAHUDYLqpGkBLDciA6TCc6GOxN4/S3WiSxg==",
+			"dev": true
+		},
+		"@azure/msal-node": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-2.7.0.tgz",
+			"integrity": "sha512-wXD8LkUvHICeSWZydqg6o8Yvv+grlBEcmLGu+QEI4FcwFendbTEZrlSygnAXXSOCVaGAirWLchca35qrgpO6Jw==",
+			"dev": true,
+			"requires": {
+				"@azure/msal-common": "14.9.0",
+				"jsonwebtoken": "^9.0.0",
+				"uuid": "^8.3.0"
+			},
+			"dependencies": {
+				"uuid": {
+					"version": "8.3.2",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+					"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+					"dev": true
+				}
+			}
+		},
 		"@eslint-community/eslint-utils": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -5628,6 +6261,25 @@
 			"dev": true,
 			"optional": true
 		},
+		"@redhat-developer/locators": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@redhat-developer/locators/-/locators-1.1.0.tgz",
+			"integrity": "sha512-sSSyA1Le5ju9kvD2uY8AUKZk3iJ/ocL6KpJmBMnhecYcH96cATw9mow/5OkDEnwWihefcieerlsVRGHIQlhh0Q==",
+			"dev": true,
+			"requires": {}
+		},
+		"@redhat-developer/page-objects": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@redhat-developer/page-objects/-/page-objects-1.1.0.tgz",
+			"integrity": "sha512-h+WDFrTFcvJJq33vhakzjlFgE2tM7K0nCwonDgDuGUoW9ukerb+M/dM7m3qEGwW5T+ugz240fGElAn4jsEHBZg==",
+			"dev": true,
+			"requires": {
+				"clipboardy": "^4.0.0",
+				"clone-deep": "^4.0.1",
+				"compare-versions": "^6.1.0",
+				"fs-extra": "^11.2.0"
+			}
+		},
 		"@redhat-developer/vscode-redhat-telemetry": {
 			"version": "0.7.1",
 			"resolved": "https://registry.npmjs.org/@redhat-developer/vscode-redhat-telemetry/-/vscode-redhat-telemetry-0.7.1.tgz",
@@ -5652,13 +6304,6 @@
 				"@lukeed/uuid": "^2.0.0",
 				"dset": "^3.1.2",
 				"tslib": "^2.4.1"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.5.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-					"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-				}
 			}
 		},
 		"@segment/analytics-node": {
@@ -5670,19 +6315,12 @@
 				"@segment/analytics-core": "1.2.1",
 				"node-fetch": "^2.6.7",
 				"tslib": "^2.4.1"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.5.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-					"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-				}
 			}
 		},
 		"@sindresorhus/is": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-6.2.0.tgz",
-			"integrity": "sha512-yM/IGPkVnYGblhDosFBwq0ZGdnVSBkNV4onUtipGMOjZd4kB6GAu3ys91aftSbyMHh6A2GPdt+KDI5NoWP63MQ==",
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.6.0.tgz",
+			"integrity": "sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==",
 			"dev": true
 		},
 		"@szmarczak/http-timer": {
@@ -6084,11 +6722,12 @@
 			}
 		},
 		"@vscode/vsce": {
-			"version": "2.25.0",
-			"resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-2.25.0.tgz",
-			"integrity": "sha512-VXMCGUaP6wKBadA7vFQdsksxkBAMoh4ecZgXBwauZMASAgnwYesHyLnqIyWYeRwjy2uEpitHvz/1w5ENnR30pg==",
+			"version": "2.26.0",
+			"resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-2.26.0.tgz",
+			"integrity": "sha512-v54ltgMzUG8lGY0kAgaOlry57xse1RlWzes9FotfGEx+Fr05KeR8rZicQzEMDmi9QnOgVWHuiEq+xA2HWkAz+Q==",
 			"dev": true,
 			"requires": {
+				"@azure/identity": "^4.1.0",
 				"azure-devops-node-api": "^12.5.0",
 				"chalk": "^2.4.2",
 				"cheerio": "^1.0.0-rc.9",
@@ -6418,6 +7057,12 @@
 			"version": "0.2.13",
 			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
 			"integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+			"dev": true
+		},
+		"buffer-equal-constant-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
 			"dev": true
 		},
 		"buffer-fill": {
@@ -6835,6 +7480,12 @@
 				"gopd": "^1.0.1"
 			}
 		},
+		"define-lazy-prop": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+			"integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+			"dev": true
+		},
 		"delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -6918,6 +7569,15 @@
 			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
 			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
 			"dev": true
+		},
+		"ecdsa-sig-formatter": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "^5.0.1"
+			}
 		},
 		"emoji-regex": {
 			"version": "8.0.0",
@@ -7080,6 +7740,12 @@
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
 			"dev": true
 		},
+		"events": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+			"dev": true
+		},
 		"execa": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
@@ -7236,9 +7902,9 @@
 			}
 		},
 		"form-data-encoder": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-4.0.2.tgz",
-			"integrity": "sha512-KQVhvhK8ZkWzxKxOr56CPulAhH3dobtuQ4+hNQ+HekH/Wp5gSOafqRAeTphQUJAIk0GBvHZgJ2ZGRWd5kphMuw==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz",
+			"integrity": "sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==",
 			"dev": true
 		},
 		"fs-constants": {
@@ -7393,28 +8059,28 @@
 			}
 		},
 		"got": {
-			"version": "14.2.1",
-			"resolved": "https://registry.npmjs.org/got/-/got-14.2.1.tgz",
-			"integrity": "sha512-KOaPMremmsvx6l9BLC04LYE6ZFW4x7e4HkTe3LwBmtuYYQwpeS4XKqzhubTIkaQ1Nr+eXxeori0zuwupXMovBQ==",
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/got/-/got-13.0.0.tgz",
+			"integrity": "sha512-XfBk1CxOOScDcMr9O1yKkNaQyy865NbYs+F7dr4H0LZMVgCj2Le59k6PqbNHoL5ToeaEQUYh6c6yMfVcc6SJxA==",
 			"dev": true,
 			"requires": {
-				"@sindresorhus/is": "^6.1.0",
+				"@sindresorhus/is": "^5.2.0",
 				"@szmarczak/http-timer": "^5.0.1",
 				"cacheable-lookup": "^7.0.0",
-				"cacheable-request": "^10.2.14",
+				"cacheable-request": "^10.2.8",
 				"decompress-response": "^6.0.0",
-				"form-data-encoder": "^4.0.2",
-				"get-stream": "^8.0.1",
-				"http2-wrapper": "^2.2.1",
+				"form-data-encoder": "^2.1.2",
+				"get-stream": "^6.0.1",
+				"http2-wrapper": "^2.1.10",
 				"lowercase-keys": "^3.0.0",
-				"p-cancelable": "^4.0.1",
+				"p-cancelable": "^3.0.0",
 				"responselike": "^3.0.0"
 			},
 			"dependencies": {
 				"get-stream": {
-					"version": "8.0.1",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
-					"integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+					"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
 					"dev": true
 				}
 			}
@@ -7775,6 +8441,47 @@
 				"universalify": "^2.0.0"
 			}
 		},
+		"jsonwebtoken": {
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+			"integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+			"dev": true,
+			"requires": {
+				"jws": "^3.2.2",
+				"lodash.includes": "^4.3.0",
+				"lodash.isboolean": "^3.0.3",
+				"lodash.isinteger": "^4.0.4",
+				"lodash.isnumber": "^3.0.3",
+				"lodash.isplainobject": "^4.0.6",
+				"lodash.isstring": "^4.0.1",
+				"lodash.once": "^4.0.0",
+				"ms": "^2.1.1",
+				"semver": "^7.5.4"
+			},
+			"dependencies": {
+				"jwa": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+					"integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+					"dev": true,
+					"requires": {
+						"buffer-equal-constant-time": "1.0.1",
+						"ecdsa-sig-formatter": "1.0.11",
+						"safe-buffer": "^5.0.1"
+					}
+				},
+				"jws": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+					"integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+					"dev": true,
+					"requires": {
+						"jwa": "^1.4.1",
+						"safe-buffer": "^5.0.1"
+					}
+				}
+			}
+		},
 		"jszip": {
 			"version": "3.10.1",
 			"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
@@ -7785,6 +8492,27 @@
 				"pako": "~1.0.2",
 				"readable-stream": "~2.3.6",
 				"setimmediate": "^1.0.5"
+			}
+		},
+		"jwa": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+			"integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+			"dev": true,
+			"requires": {
+				"buffer-equal-constant-time": "1.0.1",
+				"ecdsa-sig-formatter": "1.0.11",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"jws": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+			"integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+			"dev": true,
+			"requires": {
+				"jwa": "^2.0.0",
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"keytar": {
@@ -7864,10 +8592,52 @@
 				"p-locate": "^5.0.0"
 			}
 		},
+		"lodash.includes": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+			"integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+			"dev": true
+		},
+		"lodash.isboolean": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+			"integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+			"dev": true
+		},
+		"lodash.isinteger": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+			"integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+			"dev": true
+		},
+		"lodash.isnumber": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+			"integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+			"dev": true
+		},
+		"lodash.isplainobject": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+			"dev": true
+		},
+		"lodash.isstring": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+			"integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+			"dev": true
+		},
 		"lodash.merge": {
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+			"dev": true
+		},
+		"lodash.once": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+			"integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
 			"dev": true
 		},
 		"log-symbols": {
@@ -8140,27 +8910,6 @@
 				}
 			}
 		},
-		"monaco-page-objects": {
-			"version": "3.14.1",
-			"resolved": "https://registry.npmjs.org/monaco-page-objects/-/monaco-page-objects-3.14.1.tgz",
-			"integrity": "sha512-+inJ9rwxYraQFCA+YpjyYcoxmNHcEsxPH7bPhmeaZ09eRh0o3RQqFRZDkibFOraDpKiC5miqEDYR9pJx+hau4Q==",
-			"dev": true,
-			"requires": {
-				"clipboardy": "^4.0.0",
-				"clone-deep": "^4.0.1",
-				"compare-versions": "^6.1.0",
-				"fs-extra": "^11.2.0",
-				"type-fest": "^4.14.0"
-			},
-			"dependencies": {
-				"type-fest": {
-					"version": "4.15.0",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.15.0.tgz",
-					"integrity": "sha512-tB9lu0pQpX5KJq54g+oHOLumOx+pMep4RaM6liXh2PKmVRFF+/vAtUP0ZaJ0kOySfVNjF6doBWPHhBhISKdlIA==",
-					"dev": true
-				}
-			}
-		},
 		"ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -8222,9 +8971,9 @@
 			"dev": true
 		},
 		"node-abi": {
-			"version": "3.58.0",
-			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.58.0.tgz",
-			"integrity": "sha512-pXY1jnGf5T7b8UNzWzIqf0EkX4bx/w8N2AvwlGnk2SYYA/kzDVPaH0Dh0UG4EwxBB5eKOIZKPr8VAHSHL1DPGg==",
+			"version": "3.62.0",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.62.0.tgz",
+			"integrity": "sha512-CPMcGa+y33xuL1E0TcNIu4YyaZCxnnvkVaEXrsosR3FxN+fV8xvb7Mzpb7IgKler10qeMkE6+Dp8qJhpzdq35g==",
 			"dev": true,
 			"optional": true,
 			"requires": {
@@ -8302,6 +9051,34 @@
 				"mimic-fn": "^2.1.0"
 			}
 		},
+		"open": {
+			"version": "8.4.2",
+			"resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+			"integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+			"dev": true,
+			"requires": {
+				"define-lazy-prop": "^2.0.0",
+				"is-docker": "^2.1.1",
+				"is-wsl": "^2.2.0"
+			},
+			"dependencies": {
+				"is-docker": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+					"integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+					"dev": true
+				},
+				"is-wsl": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+					"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+					"dev": true,
+					"requires": {
+						"is-docker": "^2.0.0"
+					}
+				}
+			}
+		},
 		"optionator": {
 			"version": "0.9.3",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
@@ -8327,9 +9104,9 @@
 			}
 		},
 		"p-cancelable": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-4.0.1.tgz",
-			"integrity": "sha512-wBowNApzd45EIKdO1LaU+LrMBwAcjfPaYtVzV3lmfM3gf8Z4CHZsiIqlM8TZZ8okYvh5A1cP6gTfCRQtwUpaUg==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
+			"integrity": "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==",
 			"dev": true
 		},
 		"p-defer": {
@@ -8808,6 +9585,12 @@
 			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
 			"dev": true
 		},
+		"stoppable": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
+			"integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
+			"dev": true
+		},
 		"string_decoder": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -9036,6 +9819,11 @@
 			"dev": true,
 			"requires": {}
 		},
+		"tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
 		"tunnel": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
@@ -9146,45 +9934,38 @@
 			"integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
 		},
 		"vscode-extension-tester": {
-			"version": "7.3.2",
-			"resolved": "https://registry.npmjs.org/vscode-extension-tester/-/vscode-extension-tester-7.3.2.tgz",
-			"integrity": "sha512-qjswvU00k+n9yeC4cJupm2067cZAm+cxMVmbcssZp4lI6OMbbUDP4s2c9i1sODwCv8MTzzzQw+z6+4xagUeQmA==",
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/vscode-extension-tester/-/vscode-extension-tester-8.1.0.tgz",
+			"integrity": "sha512-gXyGi4D+ZqemAvt7IegFUBxVLQH1ftTRiMKqlwH1BBi+x1yhPXXuIVo6TSWUlyGMznbpFV5DUK3GEAfc13nSsg==",
 			"dev": true,
 			"requires": {
+				"@redhat-developer/locators": "^1.1.0",
+				"@redhat-developer/page-objects": "^1.1.0",
 				"@types/selenium-webdriver": "^4.1.22",
-				"@vscode/vsce": "^2.24.0",
+				"@vscode/vsce": "^2.26.0",
 				"commander": "^12.0.0",
 				"compare-versions": "^6.1.0",
 				"fs-extra": "^11.2.0",
-				"glob": "^10.3.10",
-				"got": "^14.2.1",
+				"glob": "^10.3.12",
+				"got": "^13.0.0",
 				"hpagent": "^1.2.0",
 				"js-yaml": "^4.1.0",
-				"monaco-page-objects": "^3.14.1",
 				"sanitize-filename": "^1.6.3",
-				"selenium-webdriver": "^4.18.1",
-				"targz": "^1.0.1",
-				"vscode-extension-tester-locators": "^3.12.2"
+				"selenium-webdriver": "^4.19.0",
+				"targz": "^1.0.1"
 			}
 		},
-		"vscode-extension-tester-locators": {
-			"version": "3.12.2",
-			"resolved": "https://registry.npmjs.org/vscode-extension-tester-locators/-/vscode-extension-tester-locators-3.12.2.tgz",
-			"integrity": "sha512-RMN+AMGhK4dSPauJoAQ1Os4Kju9br7HvcwflkgWn7M81HEo2lt/wEsLKtEm0igSc3u4iKDH3R1D/kqbxW8A/UQ==",
-			"dev": true,
-			"requires": {}
-		},
 		"vscode-uitests-tooling": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/vscode-uitests-tooling/-/vscode-uitests-tooling-4.1.0.tgz",
-			"integrity": "sha512-pcRrCAmFtTnWq9qyP6zcx2lTuXLzHSQ8tvO814WzXbSLCFqAw7gKq+wsaFLYvYVeZ0XHKB7rQ3fDU7PNGbAxUw==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/vscode-uitests-tooling/-/vscode-uitests-tooling-4.1.1.tgz",
+			"integrity": "sha512-E3ZDmuBeSMo64+0Di+Us6IN5YEu6tciVsLLd3XMBIOmhW/hh+RKKpyCKrczPx6zfKESl5eLbnJ7CTFKtu4URRw==",
 			"dev": true,
 			"requires": {
 				"clipboardy": "^4.0.0",
 				"fs-extra": "^11.2.0",
 				"sanitize-filename": "^1.6.3",
 				"tree-kill": "^1.2.2",
-				"vscode-extension-tester": "^7.3.2"
+				"vscode-extension-tester": "^8.1.0"
 			}
 		},
 		"webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -273,7 +273,7 @@
 		"mocha-jenkins-reporter": "^0.4.8",
 		"mvn-artifact-download": "^6.1.1",
 		"typescript": "^5.4.5",
-		"vscode-uitests-tooling": "^4.1.0"
+		"vscode-uitests-tooling": "^4.1.1"
 	},
 	"dependencies": {
 		"@redhat-developer/vscode-redhat-telemetry": "^0.7.1",


### PR DESCRIPTION
Brings latest release of ExTester v8.1.0