### PR TITLE
FUSETOOLS2-2388: Provide guidance when no folder is opened and commands cannot work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the "vscode-debug-adapter-apache-camel" extension will be
 
 ## 0.14.0
 
+- Added warning notification when users are trying to run or debug integration without opened folder/workspace
+
 ## 0.13.0
 
 - Update default Camel version used for Camel JBang from 4.4.0 to 4.5.0

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,6 +26,7 @@ let telemetryService: TelemetryService;
 const CAMEL_DEBUG_ADAPTER_ID = 'apache.camel';
 export const CAMEL_RUN_AND_DEBUG_WITH_JBANG_COMMAND_ID = 'apache.camel.debug.jbang';
 export const CAMEL_RUN_WITH_JBANG_COMMAND_ID = 'apache.camel.run.jbang';
+export const WORKSPACE_WARNING_MESSAGE = `The action requires an opened folder/workspace to complete successfully.`;
 
 export async function activate(context: vscode.ExtensionContext) {
 	vscode.debug.registerDebugAdapterDescriptorFactory(CAMEL_DEBUG_ADAPTER_ID, new CamelDebugAdapterDescriptorFactory(context));
@@ -40,6 +41,10 @@ export async function activate(context: vscode.ExtensionContext) {
 	await telemetryService.sendStartupEvent();
 
 	vscode.commands.registerCommand(CAMEL_RUN_AND_DEBUG_WITH_JBANG_COMMAND_ID, async (uri: vscode.Uri) => {
+		if (!vscode.workspace.workspaceFolders) {
+			await vscode.window.showWarningMessage(WORKSPACE_WARNING_MESSAGE);
+			return;
+		}
 		if (uri !== undefined) {
 			await vscode.window.showTextDocument(uri);
 		}
@@ -54,6 +59,10 @@ export async function activate(context: vscode.ExtensionContext) {
 	});
 
 	vscode.commands.registerCommand(CAMEL_RUN_WITH_JBANG_COMMAND_ID, async function () {
+		if (!vscode.workspace.workspaceFolders) {
+			await vscode.window.showWarningMessage(WORKSPACE_WARNING_MESSAGE);
+			return;
+		}
 		const camelRunTask = (await vscode.tasks.fetchTasks()).find((t) => t.name === CamelJBangTaskProvider.labelProvidedRunTask);
 		if (camelRunTask) {
 			await sendCommandTrackingEvent(telemetryService, CAMEL_RUN_WITH_JBANG_COMMAND_ID);


### PR DESCRIPTION
unfortunately I did not find out way how to easily grey out (disable) buttons when some conditions are not met.. so I have provided notification which is displayed when some action (eg run button click) is trying to execute jbang command with missing opened folder/workspace

![Screenshot 2024-05-02 at 17 08 16](https://github.com/camel-tooling/camel-dap-client-vscode/assets/18696866/8e5d7ffa-76f8-4a49-95ae-f0822b839053)
