### PR TITLE
Avoid unexpected white spaces inserting into jbang command arguments

### DIFF
--- a/src/task/CamelJBangTaskProvider.ts
+++ b/src/task/CamelJBangTaskProvider.ts
@@ -61,10 +61,10 @@ export class CamelJBangTaskProvider implements TaskProvider {
 						"value": '--dep=org.apache.camel:camel-debug',
 						"quoting": ShellQuoting.Strong
 					},
-					`${this.getCamelVersion()}`,
-					`${this.getRedHatMavenRepository()}`,
-					...this.getExtraLaunchParameter(),
-				],
+					this.getCamelVersion(),
+					this.getRedHatMavenRepository(),
+					...this.getExtraLaunchParameter()
+				].filter(function (arg) { return arg; }), // remove ALL empty values ("", null, undefined and 0)
 				shellExecOptions
 			),
 			'$camel.debug.problemMatcher'
@@ -92,10 +92,10 @@ export class CamelJBangTaskProvider implements TaskProvider {
 					'${relativeFile}',
 					'--dev',
 					'--logging-level=info',
-					`${this.getCamelVersion()}`,
-					`${this.getRedHatMavenRepository()}`,
+					this.getCamelVersion(),
+					this.getRedHatMavenRepository(),
 					...this.getExtraLaunchParameter()
-				]
+				].filter(function (arg) { return arg; }) // remove ALL empty values ("", null, undefined and 0)
 			)
 		);
 		runTask.isBackground = true;
@@ -141,9 +141,9 @@ export class CamelJBangTaskProvider implements TaskProvider {
 		}
 	}
 
-	private getExtraLaunchParameter(): string[]{
+	private getExtraLaunchParameter(): string[] {
 		const extraLaunchParameter = workspace.getConfiguration().get('camel.debugAdapter.ExtraLaunchParameter') as string[];
-		if(extraLaunchParameter){
+		if (extraLaunchParameter) {
 			return extraLaunchParameter;
 		} else {
 			return [];

--- a/src/test/suite/camel.extra.launch.parameter.settings.test.ts
+++ b/src/test/suite/camel.extra.launch.parameter.settings.test.ts
@@ -47,7 +47,7 @@ suite('Should run commands with the extra launch parameter specified in settings
 		await config.update(EXTRA_LAUNCH_PARAMETER_ID, EXTRA_LAUNCH_PARAMETER);
 
 		const camelRunTask = await getCamelTask(CamelJBangTaskProvider.labelProvidedRunTask);
-		const extraLaunchParameterPosition = 8;
+		const extraLaunchParameterPosition = 6;
 		
 		expect((getTaskCommandArguments(camelRunTask)![extraLaunchParameterPosition] as string)).to.includes(EXTRA_LAUNCH_PARAMETER[0]);
 	});
@@ -59,7 +59,7 @@ suite('Should run commands with the extra launch parameter specified in settings
 		await config.update(EXTRA_LAUNCH_PARAMETER_ID, EXTRA_LAUNCH_PARAMETER);
 
 		const camelRunAndDebugTask = await getCamelTask(CamelJBangTaskProvider.labelProvidedTask);
-		const extraLaunchParameterPosition = 10;
+		const extraLaunchParameterPosition = 8;
 		expect((getTaskCommandArguments(camelRunAndDebugTask)![extraLaunchParameterPosition] as string)).to.includes(EXTRA_LAUNCH_PARAMETER[0]);
 	});
 


### PR DESCRIPTION
before:
![Screenshot 2024-05-22 at 10 49 52](https://github.com/camel-tooling/camel-dap-client-vscode/assets/18696866/575d763b-f331-4d92-9b83-23a0141c37c4)

after:
![Screenshot 2024-05-22 at 10 50 43](https://github.com/camel-tooling/camel-dap-client-vscode/assets/18696866/6d8f8413-e79b-43c8-8a67-aa874a566bb4)
