### PR TITLE
Use released Camel Debug Adapter 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the "vscode-debug-adapter-apache-camel" extension will be
 
 - Support remote debug through http (when using Jolokia on server-side)
 - Update default Camel version used for Camel JBang from 4.6.0 to 4.7.0
+- Upgrade embedded Debug Adapter for Apache Camel to 1.2.0
 
 ## 1.1.0
 

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,12 +1,12 @@
 'use strict';
 
-const dapServerVersion = '1.2.0-SNAPSHOT';
+const dapServerVersion = '1.2.0';
 
 const download = require('mvn-artifact-download').default;
 const fs = require('fs');
 const path = require('path');
 
-const MAVEN_REPO_URL = 'https://oss.sonatype.org/content/repositories/snapshots/';
+const MAVEN_REPO_URL = 'https://oss.sonatype.org/content/repositories/releases/';
 
 download('com.github.camel-tooling:camel-dap-server:' + dapServerVersion, './jars/', MAVEN_REPO_URL).then((filename)=>{
 	fs.renameSync(filename, path.join('.', 'jars', 'camel-dap-server.jar'));


### PR DESCRIPTION
requires https://github.com/camel-tooling/camel-debug-adapter/pull/344 and publish on Maven repository