### PR TITLE
Increase minimal version tested to 1.90.2

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        version: [ "1.86.2", max ] # [ "x.x.x" | latest | max ]
+        version: [ "1.90.2", max ] # [ "x.x.x" | latest | max ]
         type: [ stable ] # [ stable | insider ]
       fail-fast: false
     timeout-minutes: 25

--- a/src/ui-test/utils.ts
+++ b/src/ui-test/utils.ts
@@ -48,7 +48,7 @@ import { ENABLING_CAMEL_DEBUGGER } from './variables';
 import { storageFolder } from "./uitest_runner";
 
 // the changes in debug side bar view were presented for new VS Code versions
-export const DEBUG_ITEM_OPERATOR = VSBrowser.instance.version > '1.90.0' ? ' =' : ':';
+export const DEBUG_ITEM_OPERATOR = VSBrowser.instance.version > '1.90.9' ? ' =' : ':';
 
 export const DEFAULT_HEADER = 'YamlHeader';
 export const DEFAULT_PROPERTY = 'yaml-dsl';


### PR DESCRIPTION
it will improve test stability.
It remains that we are testing 2 versions back in time to let users time to upgrade.
No changing the minimal engine version as in theory it should continue to work.