### PR TITLE
FUSETOOLS2-2503 - Include *.xsl files by default when running with Camel JBang

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -79,10 +79,17 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: xvfb-run --auto-servernum npm run ui-test
 
-      - name: ui test (macos, windows)
-        id: uiTest_MacOS_Windows
-        if: matrix.os != 'ubuntu-latest'
+      - name: ui test (macos)
+        id: uiTest_MacOS
+        if: matrix.os == 'macos-latest'
         run: npm run ui-test
+      
+      - name: ui test windows
+        id: uiTest_Windows
+        if: matrix.os == 'windows-latest'
+        run: |
+          Set-DisplayResolution -Width 1920 -Height 1080 -Force
+          npm run ui-test
 
       - name: vsce package
         run: vsce package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the "vscode-debug-adapter-apache-camel" extension will be
 
 - Update default Camel version used for Camel JBang from 4.7.0 to 4.8.1
 - Provide command for a deployment of Camel standalone file using Camel JBang Kubernetes plugin. It is available for Camel JBang version 4.8+.
+- Include `*.xsl` files by default when launching with Camel JBang
 
 ## 1.3.0
 

--- a/package.json
+++ b/package.json
@@ -109,7 +109,8 @@
 					"additionalProperties": false,
 					"markdownDescription": "User defined parameter to be applied at every launch. In case of spaces, the values needs to be enclosed with quotes. Default value is `[\"--local-kamelet-dir=.\"]`\n\n**Note**: Excluding `--dev`, `--logging-level`, `--dep`, `--camel-version` and `--repos` which are already being used\n\nFor possible values see:\n\n camel run --help\n\nor\n\njbang camel@apache/camel run --help",
 					"default": [
-						"--local-kamelet-dir=."
+						"--local-kamelet-dir=.",
+						"*.xsl"
 					]
 				},
 				"camel.debugAdapter.KubernetesRunParameters": {

--- a/src/ui-test/tests/camel.settings.test.ts
+++ b/src/ui-test/tests/camel.settings.test.ts
@@ -143,7 +143,7 @@ describe('Camel User Settings', function () {
 
             const items = await arraySetting.getItems();
             expect(items).is.not.empty;
-            expect(items.length).is.equal(2);
+            expect(items.length).is.equal(3);
         });
 
         it('Should influence result of "run with JBang" task', async function () {
@@ -162,7 +162,7 @@ describe('Camel User Settings', function () {
             await waitUntilItemNotExists(newParameter, arraySetting);
 
             const values = await arraySetting.getValues();
-            expect(values.length).is.lessThan(2);
+            expect(values.length).is.lessThan(3);
             expect(values).not.includes(newParameter);
             await cleanEnvironment();
         });


### PR DESCRIPTION
I feel the best place to test it is at global level with the full extension pack available as there can be movign part in several places. So I reported:  https://issues.redhat.com/browse/FUSETOOLS2-2497 . What do you think?