### PR TITLE
fix: some parameters in shell execution can make problems which leads to task failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ test-resources
 .test-extensions
 *sbom.json
 coverage
+test Fixture with speci@l chars/.vscode/settings.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the "vscode-debug-adapter-apache-camel" extension will be
 ## 1.5.0
 
 - Use containing folder by default with commands and quick editor action when launching a specific Camel Route. It allows to have other relative parameters still working when it is inside a subfolder.
+- Skip '*.xsl' argument for all run commands when there is none XSL file found in a workspace
 
 ## 1.4.0
 


### PR DESCRIPTION
for example in zsh shell the *.xsl as jbang argument is not working, it needs to be passed with single quotes