### PR TITLE
Use containing folder directory as current working directory in task for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the "vscode-debug-adapter-apache-camel" extension will be
 
 ## 1.5.0
 
+- Use containing folder by default with commands and quick editor action when launching a specific Camel Route. It allows to have other relative parameters still working when it is inside a subfolder.
+
 ## 1.4.0
 
 - Update default Camel version used for Camel JBang from 4.7.0 to 4.8.1

--- a/src/task/CamelJBangTaskProvider.ts
+++ b/src/task/CamelJBangTaskProvider.ts
@@ -44,9 +44,9 @@ export class CamelJBangTaskProvider implements TaskProvider {
 	createTask(taskLabel: string): Task {
 		switch (taskLabel) {
 			case CamelJBangTaskProvider.labelProvidedRunWithDebugActivatedTask:
-				return this.createRunWithDebugTask(CamelJBangTaskProvider.labelProvidedRunWithDebugActivatedTask, '${relativeFile}', undefined);
+				return this.createRunWithDebugTask(CamelJBangTaskProvider.labelProvidedRunWithDebugActivatedTask, '${fileBasename}', '${fileDirname}');
 			case CamelJBangTaskProvider.labelProvidedRunTask:
-				return this.createRunTask(CamelJBangTaskProvider.labelProvidedRunTask, '${relativeFile}', undefined);
+				return this.createRunTask(CamelJBangTaskProvider.labelProvidedRunTask, '${fileBasename}', '${fileDirname}');
 			case CamelJBangTaskProvider.labelProvidedRunAllWithDebugActivatedTask:
 				return this.createRunWithDebugTask(CamelJBangTaskProvider.labelProvidedRunAllWithDebugActivatedTask, '*', undefined);
 			case CamelJBangTaskProvider.labelProvidedRunAllTask:
@@ -56,7 +56,7 @@ export class CamelJBangTaskProvider implements TaskProvider {
 			case CamelJBangTaskProvider.labelProvidedRunAllFromContainingFolderTask:
 				return this.createRunTask(CamelJBangTaskProvider.labelProvidedRunAllFromContainingFolderTask, '*', '${fileDirname}');
 			case CamelJBangTaskProvider.labelProvidedDeployTask:
-				return this.createDeployTask(CamelJBangTaskProvider.labelProvidedDeployTask, '${relativeFile}', undefined);
+				return this.createDeployTask(CamelJBangTaskProvider.labelProvidedDeployTask, '${fileBasename}', '${fileDirname}');
 			case CamelJBangTaskProvider.labelAddKubernetesPluginTask:
 				return this.createAddKubernetesPluginTask('kubernetes', CamelJBangTaskProvider.labelAddKubernetesPluginTask);
 			default:


### PR DESCRIPTION
single Camel route actions

it allows to have extra parameters still relevant when the Camel route is inside a subfolder (such as the *.xsl files or kamelets)