### PR TITLE
FUSETOOLS2-2605: workaround for codelenses that could be recomputed

### DIFF
--- a/src/ui-test/tests/codelens.test.ts
+++ b/src/ui-test/tests/codelens.test.ts
@@ -65,8 +65,14 @@ describe('JBang commands execution through command codelens', function () {
     });
 
     it(`Execute command 'apache.camel.run.jbang' with codelens '${variables.CAMEL_RUN_CODELENS}'`, async function () {
-        const codelens = await findCodelens(driver, variables.CAMEL_RUN_CODELENS);
-        await codelens.click();
+        try {
+            const codelens = await findCodelens(driver, variables.CAMEL_RUN_CODELENS);
+            await codelens.click();
+        } catch {
+            // Workaround: try another time as it seems that sometimes the codelens is recomputed and there is a stale reference error
+            const codelens = await findCodelens(driver, variables.CAMEL_RUN_CODELENS);
+            await codelens.click();
+        }
         await waitUntilTerminalHasText(driver, variables.TEST_ARRAY_RUN, 4000, 350000);
     });
 


### PR DESCRIPTION
sometimes, the codelens elements are recomputed between the time we find
the element and the time we try to click on it. it leads to stale
reference error.
Applied a workaround which is consists in retrying one time in case it
happens. It was successful 3 times in row on CI for all jobs (last
builds without the workaround, it was always failing at least one of the
matrix job)