### PR TITLE
Avoid potential activation failure when no workspace is opened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the "vscode-debug-adapter-apache-camel" extension will be
 
 ## 1.6.0
 
+- Avoid potential activation error when no workspace/folder is opened
+
 ## 1.5.0
 
 - Use containing folder by default with commands and quick editor action when launching a specific Camel Route. It allows to have other relative parameters still working when it is inside a subfolder.

--- a/src/task/CamelJBangTaskProvider.ts
+++ b/src/task/CamelJBangTaskProvider.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 import { globSync } from 'glob';
-import { CancellationToken, ProviderResult, ShellExecution, ShellExecutionOptions, ShellQuoting, Task, TaskDefinition, TaskProvider, TaskRevealKind, tasks, TaskScope, workspace, WorkspaceFolder } from 'vscode';
+import { CancellationToken, ProviderResult, ShellExecution, ShellExecutionOptions, ShellQuoting, Task, TaskDefinition, TaskProvider, TaskRevealKind, tasks, TaskScope, workspace } from 'vscode';
 
 export class CamelJBangTaskProvider implements TaskProvider {
 
@@ -273,9 +273,14 @@ export class CamelJBangTaskProvider implements TaskProvider {
 	 * it is caused by ZSH null glob option disabled by default for ZSH shell
 	 */
 	private handleMissingXslFiles(extraLaunchParameters: string[]): string[] {
-		const xsls = globSync(`${(workspace.workspaceFolders as WorkspaceFolder[])[0].uri.path}/**/*.xsl`).length > 0;
-		if (xsls) {
-			return extraLaunchParameters; // don't modify default extra launch parameters specified via settings which should by default contain *.xsl
+		const workspaceFolders = workspace.workspaceFolders;
+		if (workspaceFolders !== undefined && workspaceFolders.length !== 0) {
+			const xsls = globSync(`${workspaceFolders[0].uri.path}/**/*.xsl`).length > 0;
+			if (xsls) {
+				return extraLaunchParameters; // don't modify default extra launch parameters specified via settings which should by default contain *.xsl
+			} else {
+				return extraLaunchParameters.filter(parameter => parameter !== '*.xsl');
+			}
 		} else {
 			return extraLaunchParameters.filter(parameter => parameter !== '*.xsl');
 		}


### PR DESCRIPTION
```
2025-01-21 14:54:53.619 [info] ExtensionService#_doActivateExtension redhat.vscode-debug-adapter-apache-camel, startup: false, activationEvent: 'onStartupFinished', root cause: redhat.vscode-kaoto
2025-01-21 14:54:59.972 [error] TypeError: Cannot read properties of undefined (reading '0')
	at CamelJBangTaskProvider.handleMissingXslFiles (d:\a\vscode-kaoto\vscode-kaoto\.vscode-test\extensions\redhat.vscode-debug-adapter-apache-camel-1.5.0\out\task\CamelJBangTaskProvider.js:227:81)
	at CamelJBangTaskProvider.getExtraLaunchParameter (d:\a\vscode-kaoto\vscode-kaoto\.vscode-test\extensions\redhat.vscode-debug-adapter-apache-camel-1.5.0\out\task\CamelJBangTaskProvider.js:216:25)
	at CamelJBangTaskProvider.createRunWithDebugTask (d:\a\vscode-kaoto\vscode-kaoto\.vscode-test\extensions\redhat.vscode-debug-adapter-apache-camel-1.5.0\out\task\CamelJBangTaskProvider.js:172:21)
	at CamelJBangTaskProvider.createTask (d:\a\vscode-kaoto\vscode-kaoto\.vscode-test\extensions\redhat.vscode-debug-adapter-apache-camel-1.5.0\out\task\CamelJBangTaskProvider.js:46:29)
	at CamelJBangTaskProvider.provideTasks (d:\a\vscode-kaoto\vscode-kaoto\.vscode-test\extensions\redhat.vscode-debug-adapter-apache-camel-1.5.0\out\task\CamelJBangTaskProvider.js:33:25)
	at file:///d:/a/vscode-kaoto/vscode-kaoto/.vscode-test/vscode-win32-x64-archive-1.96.4/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:122:53653
	at file:///d:/a/vscode-kaoto/vscode-kaoto/.vscode-test/vscode-win32-x64-archive-1.96.4/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:31:70494
	at new Promise (<anonymous>)
	at sr (file:///d:/a/vscode-kaoto/vscode-kaoto/.vscode-test/vscode-win32-x64-archive-1.96.4/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:31:70466)
	at ab.$provideTasks (file:///d:/a/vscode-kaoto/vscode-kaoto/.vscode-test/vscode-win32-x64-archive-1.96.4/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:122:53635)
	at Dy.S (file:///d:/a/vscode-kaoto/vscode-kaoto/.vscode-test/vscode-win32-x64-archive-1.96.4/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:32:115275)
	at Dy.Q (file:///d:/a/vscode-kaoto/vscode-kaoto/.vscode-test/vscode-win32-x64-archive-1.96.4/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:32:115055)
	at Dy.M (file:///d:/a/vscode-kaoto/vscode-kaoto/.vscode-test/vscode-win32-x64-archive-1.96.4/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:32:114144)
	at Dy.L (file:///d:/a/vscode-kaoto/vscode-kaoto/.vscode-test/vscode-win32-x64-archive-1.96.4/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:32:113249)
	at kh.value (file:///d:/a/vscode-kaoto/vscode-kaoto/.vscode-test/vscode-win32-x64-archive-1.96.4/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:32:112046)
	at P.B (file:///d:/a/vscode-kaoto/vscode-kaoto/.vscode-test/vscode-win32-x64-archive-1.96.4/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:30:746)
	at P.fire (file:///d:/a/vscode-kaoto/vscode-kaoto/.vscode-test/vscode-win32-x64-archive-1.96.4/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:30:964)
	at Vn.fire (file:///d:/a/vscode-kaoto/vscode-kaoto/.vscode-test/vscode-win32-x64-archive-1.96.4/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:32:9457)
	at kh.value (file:///d:/a/vscode-kaoto/vscode-kaoto/.vscode-test/vscode-win32-x64-archive-1.96.4/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:175:13296)
	at P.B (file:///d:/a/vscode-kaoto/vscode-kaoto/.vscode-test/vscode-win32-x64-archive-1.96.4/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:30:746)
	at P.fire (file:///d:/a/vscode-kaoto/vscode-kaoto/.vscode-test/vscode-win32-x64-archive-1.96.4/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:30:964)
	at Vn.fire (file:///d:/a/vscode-kaoto/vscode-kaoto/.vscode-test/vscode-win32-x64-archive-1.96.4/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:32:9457)
	at MessagePortMain.<anonymous> (file:///d:/a/vscode-kaoto/vscode-kaoto/.vscode-test/vscode-win32-x64-archive-1.96.4/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:175:11588)
	at MessagePortMain.emit (node:events:518:28)
	at MessagePortMain._internalPort.emit (node:electron/js2c/utility_init:2:2949)
```

for a test, see https://issues.redhat.com/browse/FUSETOOLS2-2534