### PR TITLE
Use Camel 4.10.2 by default for Camel JBang

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -44,11 +44,17 @@ jobs:
           node-version: 20
           cache: npm
 
+      - id:  setup-docker-qemu
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Start Minikube
         uses: medyagh/setup-minikube@latest
         with:
           driver: docker
-          addons: registry
+          addons: registry,registry-aliases
+          container-runtime: docker
+          insecure-registry: '10.0.0.0/24'
 
       - name: Cluster info
         run: |
@@ -63,6 +69,12 @@ jobs:
       - name: Compile
         run: npm run compile
 
+      - name: set env
+        run: |
+          eval $(minikube -p minikube docker-env)
+          echo "INSTALL_REGISTRY=$(kubectl -n kube-system get service registry -o jsonpath='{.spec.clusterIP}')" >> $GITHUB_ENV
+          echo $INSTALL_REGISTRY
+          
       - name: Allow unprivileged user namespace (ubuntu)
         run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the "vscode-debug-adapter-apache-camel" extension will be
 
 ## 1.7.0
 
-
+- Update default Camel version used for Camel JBang from 4.9.0 to 4.10.2
 
 ## 1.6.0
 

--- a/docs/content/kubernetes-deploy.md
+++ b/docs/content/kubernetes-deploy.md
@@ -25,11 +25,15 @@ To remove current integration, you can use also Camel CLI. In this case the comm
 jbang camel@apache/camel kubernetes delete --name=<name>
 ```
 
+#### Version limitations
+
+With Camel 4.8 and 4.9, the deployment in development mode is not working correctly. When using these versions, please remove the `--dev` from the list in settings: `Extensions > Debug Adapter for Apache Camel` -> `Camel > Debug Adapter: Kubernetes Run Parameters`.
+
 #### Troubleshooting
 
-For a latest releases of Camel (4.8.1+) there could be problem when deleting deployments using Camel Jbang CLI, for details you can see reported upstream issue [CAMEL-21388](https://issues.apache.org/jira/browse/CAMEL-21388).
+For some releases of Camel (4.8.1 - 4.10) there could be problem when deleting deployments using Camel Jbang CLI, for details you can see reported upstream issue [CAMEL-21388](https://issues.apache.org/jira/browse/CAMEL-21388).
 
-In that case please try with previous version which was working better.
+In that case please try with previous or newer version which was working better.
 
 ```shell
 jbang -Dcamel.jbang.version=4.8.0 camel@apache/camel kubernetes delete --name=<name>

--- a/package.json
+++ b/package.json
@@ -122,7 +122,9 @@
 					"additionalProperties": false,
 					"markdownDescription": "User defined parameters to be applied at every deploy (See [Camel JBang Kubernetes](https://camel.apache.org/manual/camel-jbang-kubernetes.html)). In case of spaces, the values needs to be enclosed with quotes. Default value is `[\"--cluster-type=openshift\"]`\n\n**Note**: Excluding `--camel-version` which is already being set in `#camel.debugAdapter.CamelVersion#`.\n\nFor more possible values see: `camel kubernetes run --help` or `jbang camel@apache/camel kubernetes run --help`",
 					"default": [
-						"--cluster-type=openshift"
+						"--dev",
+						"--cluster-type=openshift",
+						"--verbose"
 					]
 				}
 			}

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
 				"camel.debugAdapter.JBangVersion": {
 					"type": "string",
 					"markdownDescription": "Apache Camel JBang CLI version used for internal VS Code JBang commands execution. Camel JBang CLI requirements can differ between versions, it is recommended to use `default` version to ensure all extension features work properly.\n\n**Note**: This change will affect only commands provided by Debug Adapter for Apache Camel extension.",
-					"default": "4.8.1"
+					"default": "4.10.2"
 				},
 				"camel.debugAdapter.CamelVersion": {
 					"type": "string",

--- a/src/ui-test/resources/vscode-settings-minikube.json
+++ b/src/ui-test/resources/vscode-settings-minikube.json
@@ -1,5 +1,7 @@
 {
     "camel.debugAdapter.KubernetesRunParameters": [
+        "--dev",
+        "--verbose",
         "--cluster-type=minikube",
         "--build-property=quarkus.kubernetes.image-pull-policy=Never",
         "--image-builder=docker",

--- a/src/ui-test/resources/vscode-settings-minikube.json
+++ b/src/ui-test/resources/vscode-settings-minikube.json
@@ -1,6 +1,13 @@
 {
     "camel.debugAdapter.KubernetesRunParameters": [
         "--cluster-type=minikube",
-        "--build-property=quarkus.kubernetes.image-pull-policy=Never"
+        "--build-property=quarkus.kubernetes.image-pull-policy=Never",
+        "--image-builder=docker",
+        "--image-registry",
+        "registry.minikube",
+        "--trait",
+        "container.image-push=true",
+        "--trait",
+        "container.image-pull-policy=IfNotPresent"
     ]
 }

--- a/src/ui-test/tests/deploy.kubernetes.run.test.ts
+++ b/src/ui-test/tests/deploy.kubernetes.run.test.ts
@@ -72,7 +72,7 @@ describe('Camel standalone file deployment using Camel JBang Kubernetes Run', fu
 
         // using some additional steps for CAMEL 4.9.0-SNAPSHOT / 4.8.1 version
         // because the '--dev' parameter is not working for a deployment to Kubernetes
-        await waitUntilTerminalHasText(action.getDriver(), ['BUILD SUCCESS'], 3_000, 600_000); // OpenShift requires higher timeout because it is pulling more dependencies
+        await waitUntilTerminalHasText(action.getDriver(), ['Terminal will be reused by tasks'], 3_000, 600_000); // OpenShift requires higher timeout because it is pulling more dependencies
         await killTerminal();
 
         const terminalView = await new BottomBarPanel().openTerminalView();

--- a/src/ui-test/tests/deploy.kubernetes.run.test.ts
+++ b/src/ui-test/tests/deploy.kubernetes.run.test.ts
@@ -17,32 +17,24 @@
 import { resolve, join } from 'node:path';
 import {
     after,
-    ArraySetting,
     before,
-    BottomBarPanel,
     EditorAction,
     EditorView,
     VSBrowser,
-    Workbench,
 } from 'vscode-extension-tester';
 import { killTerminal, waitUntilTerminalHasText } from '../utils';
-import { execSync } from 'child_process';
 import { CAMEL_ROUTE_YAML_WITH_SPACE } from '../variables';
 
 /**
  * Note: OC login needs to be done before executing this test for deployment into OpenShift
  */
 describe('Camel standalone file deployment using Camel JBang Kubernetes Run', function () {
-    this.timeout(600_000); // 10 minutes
+    this.timeout(900_000); // 15 minutes
 
     let editorView: EditorView;
-    let jbangVersion: string;
-    let kubernetesRunParameters: string[];
     const RESOURCES_PATH: string = resolve('src', 'ui-test', 'resources');
 
     before(async function () {
-        jbangVersion = await getJBangVersion();
-        kubernetesRunParameters = await getKubernetesRunParameters();
         await VSBrowser.instance.openResources(RESOURCES_PATH);
         await VSBrowser.instance.openResources(join(RESOURCES_PATH, CAMEL_ROUTE_YAML_WITH_SPACE));
 
@@ -55,49 +47,12 @@ describe('Camel standalone file deployment using Camel JBang Kubernetes Run', fu
     after(async function () {
         await killTerminal();
         await editorView.closeAllEditors();
-        // remove deployed integration from a local cluster
-        if (kubernetesRunParameters[0].includes('openshift')) {
-            // workaround: because of issues with 'camel kubernetes delete --name=<name>' in versions 4.8.1+ and OpenShift we need to cleanup using 'oc'
-            // see https://issues.apache.org/jira/browse/CAMEL-21702
-            execSync(`oc delete deployment demoroute`, { stdio: 'inherit' });
-        } else {
-            // minikube
-            execSync(`jbang -Dcamel.jbang.version=${jbangVersion} camel@apache/camel kubernetes delete --name=demoroute`, { stdio: 'inherit', cwd: RESOURCES_PATH });
-        }
     });
 
     it('Deploy integration to OpenShift or Kubernetes (Minikube)', async function () {
         const action = (await editorView.getAction('Deploy Integration with Apache Camel Kubernetes Run')) as EditorAction;
         await action.click();
-
-        // using some additional steps for CAMEL 4.9.0-SNAPSHOT / 4.8.1 version
-        // because the '--dev' parameter is not working for a deployment to Kubernetes
-        await waitUntilTerminalHasText(action.getDriver(), ['Terminal will be reused by tasks'], 3_000, 600_000); // OpenShift requires higher timeout because it is pulling more dependencies
-        await killTerminal();
-
-        const terminalView = await new BottomBarPanel().openTerminalView();
-        await terminalView.getDriver().wait(async () => {
-            const found = (await terminalView.getText()).match(/[A-Za-z]/g);
-            return found;
-        }, 10_000, 'New terminal shell was not opened properly.', 2_000);
-        // skip 'await' for async function to allow continue test after terminal command execution which would be blocking thread for infinity
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        terminalView.executeCommand(`jbang -Dcamel.jbang.version=${jbangVersion} camel@apache/camel kubernetes logs --name=demoroute`);
-        await waitUntilTerminalHasText(action.getDriver(), ['Hello Camel from'], 3_000, 120_000);
+        await waitUntilTerminalHasText(action.getDriver(), ['Hello Camel from'], 10_000, 900_000);
     });
-
-    async function getJBangVersion(): Promise<string> {
-        const textField = await (await new Workbench().openSettings()).findSetting('JBang Version', 'Camel', 'Debug Adapter');
-        const value = await textField.getValue() as string;
-        await new EditorView().closeEditor('Settings');
-        return value;
-    }
-
-    async function getKubernetesRunParameters(): Promise<string[]> {
-        const setting = await (await new Workbench().openSettings()).findSetting('Kubernetes Run Parameters', 'Camel', 'Debug Adapter') as ArraySetting;
-        const values = await setting.getValues();
-        await new EditorView().closeEditor('Settings');
-        return values;
-    }
 
 });


### PR DESCRIPTION
By default, Camel Jbang is now using Jib and not Docker and providing a multi-arch platform and the way to produce images are no more the same consequently:
* a specific registry must be configured. We found only using Docker to make it working with Minikube.
* qemu is required for the multi-arch with Docker
* resgitry-alias is required because vs code tasks cannot escape and interpret correctly the env command of the registry setup
* can get back to use --dev mode (was removed with 4.8.1 as it wasn't working anymore)
* add --verbose to have more information directly in the shell as it was before 4.8
* 
Note: I abandoned to search why the previous way of doing the deploy/delete was failing with this version, moved directly to use the --dev
