### PR TITLE
chore: add launch configurations to debug ui-tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -26,13 +26,47 @@
 			"request": "launch",
 			"args": [
 				"--extensionDevelopmentPath=${workspaceFolder}",
-				"--extensionTestsPath=${workspaceFolder}/out/test/suite/index",
+				"--extensionTestsPath=${workspaceFolder}/out/src/test/suite/index",
 				"${workspaceRoot}/test Fixture with speci@l chars"
 			],
 			"outFiles": [
 				"${workspaceFolder}/out/src/test/**/*.js"
 			],
 			"preLaunchTask": "npm: watch"
+		},
+		{
+			"type": "node",
+			"request": "launch",
+			"name": "Launch Camel Debug Adapter UI Tests",
+			"preLaunchTask": "npm: watch",
+			"program": "${workspaceFolder}/out/src/ui-test/uitest_runner.js",
+			"sourceMaps": true,
+			"cwd": "${workspaceFolder}",
+			"runtimeArgs": [
+				"--nolazy",
+				"--inspect"
+			],
+			"skipFiles": [
+				"<node_internals>/**"
+			],
+			"autoAttachChildProcesses": true,
+			"env": {
+				"CODE_VERSION": "max"
+			}
+		},
+		{
+			"type": "node",
+			"request": "attach",
+			"name": "Attach to Node Process",
+			"port": 9229,
+			"restart": true,
+			"timeout": 10000,
+			"sourceMaps": true,
+			"cwd": "${workspaceFolder}",
+			"skipFiles": [
+				"<node_internals>/**"
+			],
+			"autoAttachChildProcesses": true
 		}
 	]
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"Debug Adapter Protocol",
 		"Debugging"
 	],
-	"main": "./out/extension.js",
+	"main": "./out/src/extension.js",
 	"activationEvents": [
 		"onLanguage:xml",
 		"workspaceContains:**/*.xml",
@@ -329,8 +329,8 @@
 		"pretest": "npm run compile",
 		"preui-test": "npm run compile",
 		"lint": "eslint src",
-		"test": "node ./out/test/runTest.js",
-		"ui-test": "node ./out/ui-test/uitest_runner.js",
+		"test": "node ./out/src/test/runTest.js",
+		"ui-test": "node ./out/src/ui-test/uitest_runner.js",
 		"ui-test:deploy:minikube": "npm run ui-test -- minikube",
 		"ui-test:deploy:openshift": "npm run ui-test -- openshift",
 		"ui-test:coverage": "npm run ui-test -- coverage"

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -6,7 +6,7 @@ async function main() {
 	try {
 		// The folder containing the Extension Manifest package.json
 		// Passed to `--extensionDevelopmentPath`
-		const extensionDevelopmentPath = path.resolve(__dirname, '../../');
+		const extensionDevelopmentPath = path.resolve(__dirname, '../../../');
 		console.log(`extensionDevelopmentPath = ${extensionDevelopmentPath}`);
 
 		// The path to test runner
@@ -14,7 +14,7 @@ async function main() {
 		const extensionTestsPath = path.resolve(__dirname, './suite/index');
 		console.log(`extensionTestsPath = ${extensionTestsPath}`);
 
-		const testWorkspace = path.resolve(__dirname, '../../test Fixture with speci@l chars');
+		const testWorkspace = path.resolve(__dirname, '../../../test Fixture with speci@l chars');
 		console.log(`testWorkspace = ${testWorkspace}`);
 
 		const vscodeVersion = computeVSCodeVersionToPlayTestWith();

--- a/src/test/suite/camel.extra.launch.parameter.settings.test.ts
+++ b/src/test/suite/camel.extra.launch.parameter.settings.test.ts
@@ -27,7 +27,7 @@ suite('Should run commands with the extra launch parameter specified in settings
 
 	const EXTRA_LAUNCH_PARAMETER = ['--fresh'];
 	const EXTRA_LAUNCH_PARAMETER_ID = 'camel.debugAdapter.ExtraLaunchParameter';
-	const TMP_XSL_FILE = resolve(__dirname, '../../../test Fixture with speci@l chars', 'tmp-file.xsl');
+	const TMP_XSL_FILE = resolve(__dirname, '../../../../test Fixture with speci@l chars', 'tmp-file.xsl');
 
 	let defaultExtraLaunchParameter = [''];
 

--- a/src/test/suite/util.ts
+++ b/src/test/suite/util.ts
@@ -18,7 +18,7 @@ import path = require('path');
 import * as vscode from 'vscode';
 
 const getDocPath = (p: string) => {
-	return path.resolve(__dirname, '../../../test Fixture with speci@l chars', p);
+	return path.resolve(__dirname, '../../../../test Fixture with speci@l chars', p);
 };
 
 export const getDocUri = (p: string) => {

--- a/src/ui-test/uitest_runner.ts
+++ b/src/ui-test/uitest_runner.ts
@@ -21,6 +21,10 @@ import * as fs from 'fs';
 import * as variables from './variables';
 import { ExTester, ReleaseQuality } from 'vscode-extension-tester';
 
+process.on('unhandledRejection', (reason) => {
+    console.error('Unhandled Rejection:', reason);
+});
+
 export const storageFolder = variables.TEST_RESOURCES_DIR;
 const releaseType: ReleaseQuality = process.env.CODE_TYPE === 'insider' ? ReleaseQuality.Insider : ReleaseQuality.Stable;
 export const projectPath = path.resolve(__dirname, '..', '..');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,19 @@
 {
 	"compilerOptions": {
-		"module": "Node16",		
+		"module": "Node16",
 		"moduleResolution": "Node16",
 		"target": "ES2022",
 		"lib": [
-            "ES2022"
-        ],
+			"ES2022"
+		],
 		"outDir": "out",
 		"resolveJsonModule": true,
 		"strict": true,
 		"forceConsistentCasingInFileNames": true,
 		"skipLibCheck": true, // don't know how to fix it
 		"sourceMap": true,
+		"inlineSources": true,
+		"rootDir": "."
 	},
 	"include": [
 		"src"


### PR DESCRIPTION
- Adds launch configuration to start ui-tests.
- Adds launch configuration to attach to a running node process
  (usefull when launching from the terminal with VSCode's auto attach
  feature enabled).
- Adds better handling of exceptions in the ui-test runner. The
  runner will print the exception message and stack trace to the
  console.

Signed-off-by: Marcelo Henrique Diniz de Araujo <mdinizde@redhat.com>