### PR TITLE
Test with 4.8.5 instead of 4.4.5

### DIFF
--- a/.github/workflows/camel_version.yaml
+++ b/.github/workflows/camel_version.yaml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         camel-version:
-          - "4.4.5"
+          - "4.8.5"
           - "4.0.0.redhat-00036"
           - "4.4.0.redhat-00046"
     timeout-minutes: 30


### PR DESCRIPTION
4.4.5 has reached End of Life already. And 4.8.x is an LTS. 4.10 is currently tested with default version used