### PR TITLE
fix: prevent uitest_runner.js to be executed either when only some specific test is called

### DIFF
--- a/src/ui-test/uitest_runner.ts
+++ b/src/ui-test/uitest_runner.ts
@@ -73,6 +73,8 @@ async function main(): Promise<void> {
 	fs.rmSync(extensionFolder, { recursive: true });
 }
 
-main().catch((error) => {
-	throw Error('Unhandled promise rejection in main: ', error);
-});
+if (require.main === module) {
+	main().catch((error) => {
+		throw Error('Unhandled promise rejection in main: ', error);
+	});
+}


### PR DESCRIPTION
I have noticed that the all UI tests are executed all the time even if I call only one specific file to be run