### PR TITLE
Fix deploy on OpenShift by default on restricted environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the "vscode-debug-adapter-apache-camel" extension will be
 
 ## 1.8.0
 
+- Potential breakage: when using a Camel Jbang version strictly prior to 4.11, the parameter `--disable-auto` must be removed from the setting `Kubernetes Run Parameters`
 - Update default Camel version used for Camel JBang from 4.10.2 to 4.11.0
 
 ## 1.7.0

--- a/package.json
+++ b/package.json
@@ -120,10 +120,11 @@
 						"type": "string"
 					},
 					"additionalProperties": false,
-					"markdownDescription": "User defined parameters to be applied at every deploy (See [Camel JBang Kubernetes](https://camel.apache.org/manual/camel-jbang-kubernetes.html)). In case of spaces, the values needs to be enclosed with quotes. Default value is `[\"--cluster-type=openshift\"]`\n\n**Note**: Excluding `--camel-version` which is already being set in `#camel.debugAdapter.CamelVersion#`.\n\nFor more possible values see: `camel kubernetes run --help` or `jbang camel@apache/camel kubernetes run --help`",
+					"markdownDescription": "User defined parameters to be applied at every deploy (See [Camel JBang Kubernetes](https://camel.apache.org/manual/camel-jbang-kubernetes.html)). In case of spaces, the values needs to be enclosed with quotes. Default value is `[\"--cluster-type=openshift\"]`\n\n**Note**: Excluding `--camel-version` which is already being set in `#camel.debugAdapter.CamelVersion#`.\n\nBeware that `--disable-auto`, which is provided by default, requires Camel 4.11+.\n\nFor more possible values see: `camel kubernetes run --help` or `jbang camel@apache/camel kubernetes run --help`",
 					"default": [
 						"--dev",
 						"--cluster-type=openshift",
+						"--disable-auto",
 						"--verbose"
 					]
 				}


### PR DESCRIPTION
Camel 4.11 has introduced `--disable-auto` parameter without checking if the cluster-type has been already set or not.
The automatic detection does not work if connected user cannot list resource "clusterversions" in API group "config.openshift.io" at the cluster scope.

Other better ways that could be done later on:
* remove automatically the --disable-auto when detecting that the version is prior to 4.11
* forget about 4.11 and improve handling these parameters in Camel JBang