### PR TITLE
Update path to UI test screenshots on CI

### DIFF
--- a/.github/workflows/camel_version.yaml
+++ b/.github/workflows/camel_version.yaml
@@ -93,7 +93,7 @@ jobs:
           steps.uiTest.outcome == 'cancelled')
         with:
           name: ${{ matrix.camel-version }}-ui-test-screenshots
-          path: test-resources/screenshots/*.png
+          path: test-resources/screenshots/*/*.png
 
   check:
     if: always()

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -88,7 +88,7 @@ jobs:
         if: always()
         with:
           name: ui-test-screenshots
-          path: test-resources/screenshots/*.png
+          path: test-resources/screenshots/*/*.png
 
   check:
     if: always()

--- a/.github/workflows/insider.yaml
+++ b/.github/workflows/insider.yaml
@@ -130,4 +130,4 @@ jobs:
           steps.uiTest_MacOS_Windows.outcome == 'cancelled')
         with:
           name: ${{ matrix.os }}-${{ matrix.version }}-ui-test-screenshots
-          path: test-resources/screenshots/*.png
+          path: test-resources/screenshots/*/*.png

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -162,7 +162,7 @@ jobs:
           steps.uiTest_MacOS_Windows.outcome == 'cancelled')
         with:
           name: ${{ matrix.os }}-${{ matrix.version }}-ui-test-screenshots
-          path: test-resources/screenshots/*.png
+          path: test-resources/screenshots/*/*.png
 
   check:
     if: always()


### PR DESCRIPTION
last VS Code extension tester update changed the place the screenshots are stored, there is an extra folder based on a timestamp