### PR TITLE
Switch back minimal version to 1.100

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        version: [ "1.101.2", max ] # [ "x.x.x" | latest | max ]
+        version: [ "1.100.3", max ] # [ "x.x.x" | latest | max ]
         type: [ stable ] # [ stable | insider ]
       fail-fast: false
     timeout-minutes: 30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to the "vscode-debug-adapter-apache-camel" extension will be
 
 ## 1.10.0
 
-- Use Node 22 instead of Node 20, minimal version of VS Code is now 1.101
+- Use Node 22 instead of Node 20
+- Minimal version of VS Code is now 1.100
 - Update default Camel version used for Camel JBang from 4.13.0 to 4.14.0
 
 ## 1.9.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
 				"@types/glob": "^8.1.0",
 				"@types/mocha": "^10.0.10",
 				"@types/node": "^14.18.63",
-				"@types/vscode": "^1.101.0",
+				"@types/vscode": "^1.100.0",
 				"@typescript-eslint/eslint-plugin": "^8.43.0",
 				"@vscode/test-electron": "^2.3.9",
 				"async-wait-until": "^2.0.30",
@@ -38,7 +38,7 @@
 				"vscode-extension-tester": "^8.17.0"
 			},
 			"engines": {
-				"vscode": "^1.101.0"
+				"vscode": "^1.100.0"
 			}
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {
@@ -1334,9 +1334,9 @@
 			}
 		},
 		"node_modules/@types/vscode": {
-			"version": "1.101.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.101.0.tgz",
-			"integrity": "sha512-ZWf0IWa+NGegdW3iU42AcDTFHWW7fApLdkdnBqwYEtHVIBGbTu0ZNQKP/kX3Ds/uMJXIMQNAojHR4vexCEEz5Q==",
+			"version": "1.100.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.100.0.tgz",
+			"integrity": "sha512-4uNyvzHoraXEeCamR3+fzcBlh7Afs4Ifjs4epINyUX/jvdk0uzLnwiDY35UKDKnkCHP5Nu3dljl2H8lR6s+rQw==",
 			"dev": true,
 			"license": "MIT"
 		},

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"url": "https://github.com/camel-tooling/camel-dap-client-vscode/issues"
 	},
 	"engines": {
-		"vscode": "^1.101.0"
+		"vscode": "^1.100.0"
 	},
 	"categories": [
 		"Debuggers"
@@ -345,7 +345,7 @@
 		"@types/glob": "^8.1.0",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^14.18.63",
-		"@types/vscode": "^1.101.0",
+		"@types/vscode": "^1.100.0",
 		"@typescript-eslint/eslint-plugin": "^8.43.0",
 		"@vscode/test-electron": "^2.3.9",
 		"async-wait-until": "^2.0.30",


### PR DESCRIPTION
to keep it compatible with latest OpenShift Dev Spaces. In theory, using Node 22 is not a problem